### PR TITLE
Fix empty postal code column in admin

### DIFF
--- a/frontend/pages/admin/users.vue
+++ b/frontend/pages/admin/users.vue
@@ -455,8 +455,16 @@ const createUser = async () => {
 const editUser = (user) => {
     userForm.value = {
         id: user.id,
-        name: user.name,
+        first_name: user.first_name || '',
+        last_name: user.last_name || '',
         email: user.email,
+        phone: user.phone || '',
+        birth_date: user.birth_date || '',
+        street: user.street || '',
+        street_number: user.street_number || '',
+        postal_code: user.postal_code || '',
+        city: user.city || '',
+        country: user.country || 'Belgium',
         role: user.role,
         password: ''
     }


### PR DESCRIPTION
Fixes the empty postal code column in the admin user management screen by updating backend filtering, adding user creation/update routes, and improving frontend data mapping.

The original issue stemmed from multiple points: the backend's postal code filter was too restrictive (exact match), the API lacked comprehensive routes for user creation/update with address details, and the frontend wasn't correctly populating all address fields for existing users. This PR addresses these points to ensure postal codes are displayed and manageable.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e5610f5-ba34-4858-96e1-fe0105b04199">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e5610f5-ba34-4858-96e1-fe0105b04199">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

