### PR TITLE
Fix empty postal code column in admin

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -218,6 +218,11 @@ Route::prefix('admin')->group(function () {
         ]);
     });
     
+    // POST /admin/users (create)
+    Route::post('/users', [App\Http\Controllers\AdminController::class, 'createUser']);
+    // PUT /admin/users/{id} (update)
+    Route::put('/users/{id}', [App\Http\Controllers\AdminController::class, 'updateUser']);
+    
     Route::get('/users', function() {
         $token = request()->header('Authorization');
         


### PR DESCRIPTION
Add support for address fields in user creation and update API endpoints to display postal codes in the admin screen.

The postal code column was empty because the API routes for creating and updating users did not handle address-related fields, even though the frontend sent them. This PR updates the `AdminController` to validate and save these fields, and adds the necessary API routes, ensuring the postal code is correctly stored and displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8196df3-5d2c-46ee-8102-b9a976be7284">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8196df3-5d2c-46ee-8102-b9a976be7284">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

