### PR TITLE
Debug new user save error

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -140,11 +140,29 @@ class AdminController extends BaseController
      */
     public function createUser(Request $request)
     {
+        // Composer un "name" si first_name / last_name fournis (compat frontend)
+        if (!$request->filled('name')) {
+            $first = trim((string) $request->input('first_name', ''));
+            $last = trim((string) $request->input('last_name', ''));
+            if ($first || $last) {
+                $request->merge(['name' => trim($first . ' ' . $last)]);
+            }
+        }
+
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:8|confirmed',
             'role' => 'required|in:admin,teacher,student',
+            'first_name' => 'nullable|string|max:255',
+            'last_name' => 'nullable|string|max:255',
+            'phone' => 'nullable|string|max:20',
+            'street' => 'nullable|string|max:255',
+            'street_number' => 'nullable|string|max:50',
+            'postal_code' => 'nullable|string|max:20',
+            'city' => 'nullable|string|max:255',
+            'country' => 'nullable|string|max:255',
+            'birth_date' => 'nullable|date',
         ]);
 
         if ($validator->fails()) {
@@ -153,9 +171,18 @@ class AdminController extends BaseController
 
         $user = User::create([
             'name' => $request->name,
+            'first_name' => $request->input('first_name'),
+            'last_name' => $request->input('last_name'),
             'email' => $request->email,
             'password' => Hash::make($request->password),
             'role' => $request->role,
+            'phone' => $request->input('phone'),
+            'street' => $request->input('street'),
+            'street_number' => $request->input('street_number'),
+            'postal_code' => $request->input('postal_code'),
+            'city' => $request->input('city'),
+            'country' => $request->input('country'),
+            'birth_date' => $request->input('birth_date'),
             'is_active' => true,
             'status' => 'active',
         ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -288,6 +288,56 @@ Route::prefix('admin')->group(function () {
             'to' => $users->lastItem()
         ]);
     });
+
+    // Création d'un utilisateur (admin)
+    Route::post('/users', function(Request $request) {
+        $token = request()->header('Authorization');
+
+        if (!$token || !str_starts_with($token, 'Bearer ')) {
+            return response()->json(['message' => 'Missing token'], 401);
+        }
+
+        $token = substr($token, 7);
+        $personalAccessToken = \Laravel\Sanctum\PersonalAccessToken::findToken($token);
+
+        if (!$personalAccessToken) {
+            return response()->json(['message' => 'Invalid token'], 401);
+        }
+
+        $user = $personalAccessToken->tokenable;
+
+        if (!$user || $user->role !== 'admin') {
+            return response()->json(['message' => 'Access denied - Admin rights required'], 403);
+        }
+
+        // Déléguer au contrôleur pour la logique métier et la validation
+        return app(\App\Http\Controllers\AdminController::class)->createUser($request);
+    });
+
+    // Mise à jour d'un utilisateur (admin)
+    Route::put('/users/{id}', function(Request $request, $id) {
+        $token = request()->header('Authorization');
+
+        if (!$token || !str_starts_with($token, 'Bearer ')) {
+            return response()->json(['message' => 'Missing token'], 401);
+        }
+
+        $token = substr($token, 7);
+        $personalAccessToken = \Laravel\Sanctum\PersonalAccessToken::findToken($token);
+
+        if (!$personalAccessToken) {
+            return response()->json(['message' => 'Invalid token'], 401);
+        }
+
+        $user = $personalAccessToken->tokenable;
+
+        if (!$user || $user->role !== 'admin') {
+            return response()->json(['message' => 'Access denied - Admin rights required'], 403);
+        }
+
+        // Déléguer au contrôleur pour la logique métier et la validation
+        return app(\App\Http\Controllers\AdminController::class)->updateUser($request, $id);
+    });
     
     Route::put('/users/{id}/status', function(Request $request, $id) {
         $token = request()->header('Authorization');


### PR DESCRIPTION
Add missing admin user creation/update routes and adapt `AdminController` to handle `first_name`/`last_name` for user creation.

The admin panel's "new user" functionality failed because the backend lacked a `POST /api/admin/users` route and the `createUser` method expected a `name` field while the frontend sent `first_name` and `last_name`. This PR resolves both issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-77f0956e-07cb-4cc0-b993-e456f5ede50e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77f0956e-07cb-4cc0-b993-e456f5ede50e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

