### PR TITLE
Fix create user page save error

### DIFF
--- a/frontend/pages/admin/users.vue
+++ b/frontend/pages/admin/users.vue
@@ -438,17 +438,20 @@ const changePage = (page) => {
 const createUser = async () => {
     try {
         const { $api } = useNuxtApp()
-        await $api.post('/admin/users', {
-            ...userForm.value,
-            password_confirmation: userForm.value.password
-        })
+        await $api.post('/admin/users', userForm.value)
 
         closeModal()
         await loadUsers()
         alert('Utilisateur créé avec succès!')
     } catch (error) {
         console.error('Erreur lors de la création:', error)
-        alert('Erreur lors de la création de l\'utilisateur')
+        if (error.response?.data?.errors) {
+            console.error('Erreurs de validation:', error.response.data.errors)
+            const firstError = Object.values(error.response.data.errors)[0]
+            alert('Erreur de validation: ' + (Array.isArray(firstError) ? firstError[0] : firstError))
+        } else {
+            alert('Erreur lors de la création de l\'utilisateur: ' + (error.response?.data?.message || error.message))
+        }
     }
 }
 


### PR DESCRIPTION
Add `POST /admin/users` API route and enhance frontend error handling to fix user creation.

The user creation page failed because the necessary API endpoint for creating new users was not defined, causing a server error. This PR implements the missing route with robust validation and updates the frontend to display specific validation messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fa048b3-58cd-4d69-9b87-f7d2c69ac15f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fa048b3-58cd-4d69-9b87-f7d2c69ac15f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

