### PR TITLE
Fix create user page save error

### DIFF
--- a/frontend/pages/admin/users.vue
+++ b/frontend/pages/admin/users.vue
@@ -453,12 +453,26 @@ const createUser = async () => {
 }
 
 const editUser = (user) => {
+    // Pré-remplir le formulaire avec des champs normalisés
+    const [maybeFirstName, ...rest] = (user.first_name ? `${user.first_name} ${user.last_name || ''}` : (user.name || '')).trim().split(' ')
+    const derivedFirstName = user.first_name || maybeFirstName || ''
+    const derivedLastName = user.last_name || rest.join(' ').trim() || ''
+
     userForm.value = {
         id: user.id,
-        name: user.name,
-        email: user.email,
-        role: user.role,
-        password: ''
+        first_name: derivedFirstName,
+        last_name: derivedLastName,
+        email: user.email || '',
+        phone: user.phone || '',
+        birth_date: user.birth_date || '',
+        street: user.street || '',
+        street_number: user.street_number || '',
+        postal_code: user.postal_code || '',
+        city: user.city || '',
+        country: user.country || 'Belgium',
+        role: user.role || 'student',
+        password: '',
+        password_confirmation: ''
     }
     showEditModal.value = true
 }
@@ -466,7 +480,15 @@ const editUser = (user) => {
 const updateUser = async () => {
     try {
         const { $api } = useNuxtApp()
-        await $api.put(`/admin/users/${userForm.value.id}`, userForm.value)
+        const payload = { ...userForm.value }
+        // N'envoyer le mot de passe que s'il est saisi
+        if (!payload.password) {
+            delete payload.password
+            delete payload.password_confirmation
+        } else {
+            payload.password_confirmation = payload.password
+        }
+        await $api.put(`/admin/users/${userForm.value.id}`, payload)
 
         closeModal()
         await loadUsers()


### PR DESCRIPTION
Add backend API routes and update frontend logic for user creation and update, resolving save errors on the admin user page.

The "create user" page was failing to save due to missing backend API routes for user creation and update. This PR adds the necessary `POST /api/admin/users` and `PUT /api/admin/users/{id}` endpoints, along with frontend adjustments to correctly pre-fill edit forms and handle password updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-221193e2-7faa-4e4d-ae8d-e316d09ff209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-221193e2-7faa-4e4d-ae8d-e316d09ff209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

