### PR TITLE
Fix frontend build error in github actions

### DIFF
--- a/frontend/components/TeacherCalendar.vue
+++ b/frontend/components/TeacherCalendar.vue
@@ -331,7 +331,7 @@
             </div>
             
             <!-- Informations de debug -->
-            <div v-if="process.env.NODE_ENV === 'development'" class="mt-3 p-2 bg-gray-50 border border-gray-200 rounded-md">
+            <div v-if="isDevelopment" class="mt-3 p-2 bg-gray-50 border border-gray-200 rounded-md">
               <p class="text-xs text-gray-600">
                 <strong>Debug:</strong> Élèves chargés: {{ students.length }}, Formulaire valide: {{ isFormValid }}
               </p>
@@ -456,6 +456,10 @@ const weekDays = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim']
 const hours = Array.from({ length: 24 }, (_, i) => i)
 
 // Computed
+const isDevelopment = computed(() => {
+  return import.meta.env.DEV
+})
+
 const currentPeriodTitle = computed(() => {
   if (currentView.value === 'month') {
     return currentDate.value.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })


### PR DESCRIPTION
Replace `process.env.NODE_ENV` with `import.meta.env.DEV` in `TeacherCalendar.vue` to fix SSR build errors.

The previous usage of `process.env.NODE_ENV` directly in a Vue template caused an "Expected identifier but found '\"production\"'" error during the Nuxt 3 server-side rendering (SSR) build. This change replaces it with a computed property utilizing `import.meta.env.DEV`, which is the correct and SSR-safe method for checking the development environment in Nuxt 3/Vite.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ef7e27f-fbca-44cb-9eb2-b09dbacb1895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ef7e27f-fbca-44cb-9eb2-b09dbacb1895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

