### PR TITLE
perf(planning): accélérer affichage grille club

### DIFF
--- a/app/Http/Controllers/Api/ClubPlanningController.php
+++ b/app/Http/Controllers/Api/ClubPlanningController.php
@@ -423,44 +423,62 @@ class ClubPlanningController extends Controller
             ->get(['open_slot_id', 'day_of_week', 'start_time', 'end_time'])
             ->groupBy('open_slot_id');
 
+        // Une seule query lessons sur tout l'horizon + index date|heure (évite 1 get()/semaine + filter O(L))
+        $rangeStart = $weekStart->format('Y-m-d').' 00:00:00';
+        $rangeEnd = $weekStart->copy()->addWeeks($weeksCount - 1)->endOfWeek()->format('Y-m-d').' 23:59:59';
+        $occupancyIndex = [];
+        $allLessons = Lesson::where('club_id', $clubId)
+            ->where('status', '!=', 'cancelled')
+            ->whereBetween('start_time', [$rangeStart, $rangeEnd])
+            ->get(['id', 'start_time']);
+        foreach ($allLessons as $lesson) {
+            $dt = Carbon::parse($lesson->start_time);
+            $key = $dt->format('Y-m-d').'|'.$dt->format('H:i');
+            $occupancyIndex[$key] = ($occupancyIndex[$key] ?? 0) + 1;
+        }
+
+        // Pré-calcul par créneau (indépendant de la semaine)
+        $slotMeta = [];
+        foreach ($openSlots as $slot) {
+            $recurringForSlot = $recurringBySlot->get($slot->id, collect())->filter(
+                fn ($rec) => (int) $rec->day_of_week === (int) $slot->day_of_week
+            );
+            $slotMeta[$slot->id] = [
+                'time_step' => $this->calculateTimeStep($slot->courseTypes),
+                'start_minutes' => $this->timeToMinutes($slot->start_time),
+                'end_minutes' => $this->timeToMinutes($slot->end_time),
+                'max_slots' => (int) ($slot->max_slots ?? 1),
+                'recurring' => $recurringForSlot,
+                'label' => $slot->discipline->name ?? 'Créneau',
+                'time_range' => substr((string) $slot->start_time, 0, 5).' - '.substr((string) $slot->end_time, 0, 5),
+                'day_of_week' => $slot->day_of_week,
+            ];
+        }
+
         $result = [];
 
         for ($w = 0; $w < $weeksCount; $w++) {
             $startDate = $weekStart->copy()->addWeeks($w)->format('Y-m-d');
             $endDate = Carbon::parse($startDate)->endOfWeek()->format('Y-m-d');
 
-            $lessons = Lesson::where('club_id', $clubId)
-                ->where('status', '!=', 'cancelled')
-                ->whereBetween('start_time', [$startDate . ' 00:00:00', $endDate . ' 23:59:59'])
-                ->get();
-
             $weeksSlots = [];
 
             foreach ($openSlots as $slot) {
-                $timeStep = $this->calculateTimeStep($slot->courseTypes);
-                $slotStartMinutes = $this->timeToMinutes($slot->start_time);
-                $slotEndMinutes = $this->timeToMinutes($slot->end_time);
-                $maxSlots = (int) ($slot->max_slots ?? 1);
-
-                $recurringForSlot = $recurringBySlot->get($slot->id, collect())->filter(
-                    fn ($rec) => (int) $rec->day_of_week === (int) $slot->day_of_week
-                );
+                $meta = $slotMeta[$slot->id];
+                $timeStep = $meta['time_step'];
+                $slotStartMinutes = $meta['start_minutes'];
+                $slotEndMinutes = $meta['end_minutes'];
+                $maxSlots = $meta['max_slots'];
+                $recurringForSlot = $meta['recurring'];
 
                 $dates = $this->getDatesByDayOfWeek($startDate, $endDate, $slot->day_of_week);
-                $slotLabel = $slot->discipline->name ?? 'Créneau';
-                $timeRange = substr($slot->start_time, 0, 5) . ' - ' . substr($slot->end_time, 0, 5);
-
                 $datesDetail = [];
 
                 foreach ($dates as $date) {
                     $plages = [];
                     for ($min = $slotStartMinutes; $min + $timeStep <= $slotEndMinutes; $min += $timeStep) {
                         $timeStr = $this->minutesToTime($min);
-                        $occupied = $lessons->filter(function ($lesson) use ($date, $timeStr) {
-                            $d = Carbon::parse($lesson->start_time)->format('Y-m-d');
-                            $t = Carbon::parse($lesson->start_time)->format('H:i');
-                            return $d === $date && $t === $timeStr;
-                        })->count();
+                        $occupied = $occupancyIndex[$date.'|'.$timeStr] ?? 0;
                         $remaining = max(0, $maxSlots - $occupied);
                         $isRecurringPlage = $this->isTimeInRecurringRanges($timeStr, $recurringForSlot);
                         $plages[] = [
@@ -480,9 +498,9 @@ class ClubPlanningController extends Controller
 
                 $weeksSlots[] = [
                     'slot_id' => $slot->id,
-                    'slot_name' => $slotLabel,
-                    'time_range' => $timeRange,
-                    'day_of_week' => $slot->day_of_week,
+                    'slot_name' => $meta['label'],
+                    'time_range' => $meta['time_range'],
+                    'day_of_week' => $meta['day_of_week'],
                     'dates' => $datesDetail,
                 ];
             }

--- a/app/Http/Controllers/Api/LessonController.php
+++ b/app/Http/Controllers/Api/LessonController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\PlanningLessonResource;
 use App\Models\Lesson;
 use App\Models\User;
 use App\Models\Teacher;
@@ -101,18 +102,43 @@ class LessonController extends Controller
     {
         try {
             $user = Auth::user();
-            // Optimiser les relations chargées - sélectionner uniquement les colonnes nécessaires
-            // Désactiver les accessors coûteux pour améliorer les performances
-            
-            // Vérifier si la colonne color existe dans la table teachers
-            $hasColorColumn = \Illuminate\Support\Facades\Schema::hasColumn('teachers', 'color');
+            $isPlanningContext = $request->get('context') === 'planning';
+
+            // Cache one-shot : Schema::hasColumn à chaque hit était coûteux
+            static $hasColorColumn = null;
+            if ($hasColorColumn === null) {
+                $hasColorColumn = \Illuminate\Support\Facades\Schema::hasColumn('teachers', 'color');
+            }
             $teacherColumns = $hasColorColumn ? 'id,user_id,color' : 'id,user_id';
-            
-            $query = Lesson::select('lessons.id', 'lessons.teacher_id', 'lessons.student_id', 'lessons.course_type_id', 
-                                   'lessons.location_id', 'lessons.club_id', 'lessons.start_time', 'lessons.end_time', 
-                                   'lessons.status', 'lessons.price', 'lessons.notes', 'lessons.created_at', 'lessons.updated_at',
-                                   'lessons.est_legacy', 'lessons.deduct_from_subscription')
-                ->with([
+
+            $eager = $isPlanningContext
+                ? [
+                    "teacher:{$teacherColumns}",
+                    'teacher.user:id,name',
+                    'student:id,user_id,first_name,last_name,phone',
+                    'student.user:id,name,phone',
+                    // IDs seuls (badge 📋) — sans templates ni remaining_* 
+                    'student.subscriptionInstances' => function ($query) {
+                        $query->select('subscription_instances.id')
+                              ->where('status', 'active')
+                              ->where('expires_at', '>=', now())
+                              ->whereHas('subscription');
+                    },
+                    'students:id,user_id,first_name,last_name,phone',
+                    'students.user:id,name,phone',
+                    'students.subscriptionInstances' => function ($query) {
+                        $query->select('subscription_instances.id')
+                              ->where('status', 'active')
+                              ->where('expires_at', '>=', now())
+                              ->whereHas('subscription');
+                    },
+                    'courseType:id,name',
+                    'subscriptionInstances' => function ($q) {
+                        $q->select('subscription_instances.id');
+                    },
+                    'lessonRecurringSlot:id,lesson_id,recurring_slot_id',
+                ]
+                : [
                     "teacher:{$teacherColumns}",
                     'teacher.user:id,name,email',
                     'student:id,user_id,first_name,last_name,phone',
@@ -133,7 +159,13 @@ class LessonController extends Controller
                               ->with(['subscription.template']);
                     },
                     'lessonRecurringSlot:id,lesson_id,recurring_slot_id',
-                ]);
+                ];
+
+            $query = Lesson::select('lessons.id', 'lessons.teacher_id', 'lessons.student_id', 'lessons.course_type_id',
+                                   'lessons.location_id', 'lessons.club_id', 'lessons.start_time', 'lessons.end_time',
+                                   'lessons.status', 'lessons.price', 'lessons.notes', 'lessons.created_at', 'lessons.updated_at',
+                                   'lessons.est_legacy', 'lessons.deduct_from_subscription')
+                ->with($eager);
 
             $this->applyLessonAccessScope($query, $user);
 
@@ -166,7 +198,7 @@ class LessonController extends Controller
                 $now = now();
                 $dateFrom = null;
                 $dateTo = null;
-                
+
                 switch ($period) {
                     case '7days':
                         $dateFrom = $now->copy()->startOfDay();
@@ -189,71 +221,103 @@ class LessonController extends Controller
                         $dateTo = $now->copy()->addMonth()->endOfMonth()->endOfDay();
                         break;
                 }
-                
+
                 if ($dateFrom && $dateTo) {
                     $query->whereBetween('start_time', [$dateFrom, $dateTo]);
                 }
             } elseif ($request->has('date_from') || $request->has('date_to')) {
-                // Si date_from ou date_to sont fournis, les utiliser (pas de filtre par défaut)
+                // whereBetween datetime pour utiliser l'index (club_id, start_time)
                 if ($request->has('date_from')) {
-                    $query->whereDate('start_time', '>=', $request->date_from);
+                    $query->where('start_time', '>=', $request->date_from.' 00:00:00');
                 }
 
                 if ($request->has('date_to')) {
-                    $query->whereDate('start_time', '<=', $request->date_to);
+                    $query->where('start_time', '<=', $request->date_to.' 23:59:59');
                 }
             } else {
                 // Par défaut: filtrer sur les 7 prochains jours si aucune période spécifiée
                 $now = now();
                 $query->whereBetween('start_time', [
                     $now->copy()->startOfDay(),
-                    $now->copy()->addDays(7)->endOfDay()
+                    $now->copy()->addDays(7)->endOfDay(),
                 ]);
             }
 
-            // Limiter le nombre de résultats pour éviter les chargements trop longs
-            // Si date_from ET date_to sont fournis, ne pas limiter (on filtre par période)
-            // Sinon, appliquer une limite par défaut
             $hasDateRange = $request->has('date_from') && $request->has('date_to');
-            $offset = max((int) $request->get('offset', 0), 0); // Support de la pagination
+            $offset = max((int) $request->get('offset', 0), 0);
+            $wantsPaginationMeta = $request->has('offset') || $request->has('limit');
 
-            // Toujours définir $limit pour le bloc pagination JSON (évite undefined variable → 500 + CORS opaque)
             $limit = min(max((int) $request->get('limit', 50), 1), 500);
             $dateRangeCap = 10000;
 
-            // Compter le total avant pagination (pour l'historique complet)
-            $total = $query->count();
+            // Planning + plage date : pas de count() inutile (double scan)
+            $total = 0;
+            if (! ($isPlanningContext && $hasDateRange && ! $wantsPaginationMeta)) {
+                $total = $query->count();
+            }
 
-            // ✅ Tri DESC (du plus récent au plus ancien) pour l'historique, ASC pour les cours à venir
-            $orderDirection = $request->get('order', 'asc'); // 'asc' par défaut, 'desc' pour l'historique
+            $orderDirection = $request->get('order', 'asc');
             $lessonsQuery = $query->orderBy('start_time', $orderDirection);
 
-            // Appliquer offset et limit seulement si nécessaire
             if ($hasDateRange) {
                 if ($request->has('limit')) {
                     $limit = min(max((int) $request->get('limit'), 1), $dateRangeCap);
-                } else {
-                    $limit = min($total > 0 ? $total : 1, $dateRangeCap);
-                }
-                // Pas de limite SQL si on a une plage de dates complète (sauf offset / cap interne)
-                if ($offset > 0) {
+                    $lessonsQuery->offset($offset)->limit($limit);
+                } elseif ($offset > 0) {
                     $lessonsQuery->offset($offset)->limit($dateRangeCap);
+                } else {
+                    $lessonsQuery->limit($dateRangeCap);
+                }
+                if ($total === 0 && ! $wantsPaginationMeta) {
+                    $limit = $dateRangeCap;
+                } elseif (! $request->has('limit')) {
+                    $limit = min($total > 0 ? $total : 1, $dateRangeCap);
                 }
             } else {
                 $limit = min(max((int) $request->get('limit', 50), 1), 500);
                 $lessonsQuery->offset($offset)->limit($limit);
             }
-            
+
             $lessons = $lessonsQuery->get()
-                ->makeHidden(['teacher_name', 'student_name', 'duration', 'title']); // Désactiver les accessors coûteux
+                ->makeHidden(['teacher_name', 'student_name', 'duration', 'title']);
+
+            if ($isPlanningContext) {
+                // Couper les appends remaining_* (1–2 SQL / instance à la sérialisation)
+                $stripAppends = static function ($instances): void {
+                    if ($instances) {
+                        $instances->each->setAppends([]);
+                    }
+                };
+                $lessons->each(function (Lesson $lesson) use ($stripAppends) {
+                    if ($lesson->relationLoaded('subscriptionInstances')) {
+                        $stripAppends($lesson->subscriptionInstances);
+                    }
+                    if ($lesson->relationLoaded('student') && $lesson->student?->relationLoaded('subscriptionInstances')) {
+                        $stripAppends($lesson->student->subscriptionInstances);
+                    }
+                    if ($lesson->relationLoaded('students')) {
+                        foreach ($lesson->students as $student) {
+                            if ($student->relationLoaded('subscriptionInstances')) {
+                                $stripAppends($student->subscriptionInstances);
+                            }
+                        }
+                    }
+                });
+
+                $payload = PlanningLessonResource::collection($lessons)->resolve();
+            } else {
+                $payload = $lessons;
+            }
 
             $response = [
                 'success' => true,
-                'data' => $lessons
+                'data' => $payload,
             ];
-            
-            // Ajouter les informations de pagination si offset ou limit explicite
-            if ($request->has('offset') || $request->has('limit')) {
+
+            if ($wantsPaginationMeta) {
+                if ($total === 0 && $hasDateRange) {
+                    $total = count($lessons) + $offset;
+                }
                 $perPage = max($limit, 1);
                 $response['pagination'] = [
                     'total' => $total,
@@ -264,13 +328,13 @@ class LessonController extends Controller
                     'to' => min($offset + $perPage, $total),
                 ];
             }
-            
+
             return response()->json($response);
         } catch (\Exception $e) {
             return response()->json([
                 'success' => false,
                 'message' => 'Erreur lors de la récupération des cours',
-                'error' => $e->getMessage()
+                'error' => $e->getMessage(),
             ], 500);
         }
     }

--- a/app/Http/Controllers/Api/LessonController.php
+++ b/app/Http/Controllers/Api/LessonController.php
@@ -15,6 +15,7 @@ use App\Notifications\LessonCancelledNotification;
 use App\Services\LessonActionLogService;
 use App\Services\LessonBookingNotificationService;
 use App\Services\LessonCancellationAudit;
+use App\Services\ClubClosureDayService;
 use App\Services\LessonDeletionService;
 use App\Services\SubscriptionRecurringSlotRelocationService;
 use App\Models\LessonActionLog;
@@ -173,6 +174,11 @@ class LessonController extends Controller
             // L'historique élève inclut les annulés (StudentController::history, getLessonHistory)
             if (in_array($user->role, ['club', 'teacher'], true)) {
                 $query->where('status', '!=', 'cancelled');
+            }
+
+            // Enseignant : masquer aussi les cours sur un jour de fermeture club (le club les garde pour la grille).
+            if ($user->role === 'teacher') {
+                app(ClubClosureDayService::class)->excludeClosedDaysFromQuery($query);
             }
 
             // Filtres optionnels

--- a/app/Http/Controllers/Api/LessonController.php
+++ b/app/Http/Controllers/Api/LessonController.php
@@ -181,6 +181,11 @@ class LessonController extends Controller
                 app(ClubClosureDayService::class)->excludeClosedDaysFromQuery($query);
             }
 
+            // Élève : masquer les jours fermés (planning actif via GET /lessons).
+            if ($user->role === 'student') {
+                app(ClubClosureDayService::class)->excludeClosedDaysFromQuery($query);
+            }
+
             // Filtres optionnels
             if ($request->filled('teacher_id') && $user->role === 'club') {
                 $query->where('teacher_id', (int) $request->teacher_id);

--- a/app/Http/Controllers/Api/Student/DashboardController.php
+++ b/app/Http/Controllers/Api/Student/DashboardController.php
@@ -15,6 +15,7 @@ use App\Models\Location;
 use App\Models\Club;
 use App\Models\SubscriptionInstance;
 use App\Models\LessonActionLog;
+use App\Services\ClubClosureDayService;
 use App\Services\LessonActionLogService;
 use App\Services\LessonCancellationAudit;
 use App\Notifications\LessonCancellationConfirmationNotification;
@@ -125,10 +126,11 @@ class DashboardController extends Controller
         $studentId = $student->id;
 
         // Calcul des statistiques
-        $upcoming_lessons = Lesson::where('student_id', $studentId)
+        $upcomingQuery = Lesson::where('student_id', $studentId)
             ->where('status', 'confirmed')
-            ->where('start_time', '>=', Carbon::now())
-            ->count();
+            ->where('start_time', '>=', Carbon::now());
+        app(ClubClosureDayService::class)->excludeClosedDaysFromQuery($upcomingQuery);
+        $upcoming_lessons = $upcomingQuery->count();
 
         $completed_lessons = Lesson::where('student_id', $studentId)
             ->where('status', 'completed')
@@ -235,14 +237,31 @@ class DashboardController extends Controller
             ])
             ->forParticipantStudents($studentIds);
 
+        $includeCancelled = $request->boolean('include_cancelled', false);
+        $statusFilter = $request->input('status');
+        $closureDayService = app(ClubClosureDayService::class);
+
         if ($request->has('status')) {
-            $query->where('status', $request->status);
-        } elseif (! $request->boolean('include_cancelled', false)) {
-            // Planning student: hide cancelled lessons by default.
+            $query->where('status', $statusFilter);
+        } elseif (! $includeCancelled) {
             $query->where('status', '!=', 'cancelled');
         }
 
+        // Masquer les jours fermés dans les vues « actives » (planning, confirmed/pending).
+        $operationalView = ! $includeCancelled && (
+            ! $request->has('status')
+            || in_array($statusFilter, ['confirmed', 'pending'], true)
+        );
+
+        if ($operationalView) {
+            $closureDayService->excludeClosedDaysFromQuery($query);
+        }
+
         $bookings = $query->orderBy('start_time', 'desc')->get();
+
+        if (! $operationalView) {
+            $closureDayService->flagLessonsOnClosureDays($bookings);
+        }
 
         // Contexte foyer : permet à la Resource d'attribuer chaque cours à l'enfant concerné.
         $request->attributes->set('household_student_ids', $studentIds);

--- a/app/Http/Controllers/Api/Student/DashboardController.php
+++ b/app/Http/Controllers/Api/Student/DashboardController.php
@@ -123,25 +123,26 @@ class DashboardController extends Controller
             ], 404);
         }
 
-        $studentId = $student->id;
+        $studentIds = $this->getActiveStudentIds($request);
+        if ($studentIds === []) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Profil étudiant non trouvé.'
+            ], 404);
+        }
 
-        // Calcul des statistiques
-        $upcomingQuery = Lesson::where('student_id', $studentId)
+        // Calcul des statistiques (foyer : forParticipantStudents)
+        $upcomingQuery = Lesson::query()
+            ->forParticipantStudents($studentIds)
             ->where('status', 'confirmed')
             ->where('start_time', '>=', Carbon::now());
         app(ClubClosureDayService::class)->excludeClosedDaysFromQuery($upcomingQuery);
         $upcoming_lessons = $upcomingQuery->count();
 
-        $completed_lessons = Lesson::where('student_id', $studentId)
+        $completed_lessons = Lesson::query()
+            ->forParticipantStudents($studentIds)
             ->where('status', 'completed')
             ->count();
-
-        $total_hours = Lesson::where('student_id', $studentId)
-            ->where('status', 'completed')
-            ->get()
-            ->sum(function ($lesson) {
-                return Carbon::parse($lesson->start_time)->diffInMinutes(Carbon::parse($lesson->end_time));
-            }) / 60; // Convertir les minutes en heures
 
         return response()->json([
             'success' => true,
@@ -151,8 +152,8 @@ class DashboardController extends Controller
                     ->count(),
                 'activeBookings' => $upcoming_lessons,
                 'completedLessons' => $completed_lessons,
-                'favoriteTeachers' => Teacher::whereHas('lessons', function ($q) use ($studentId) {
-                    $q->where('student_id', $studentId)
+                'favoriteTeachers' => Teacher::whereHas('lessons', function ($q) use ($studentIds) {
+                    $q->forParticipantStudents($studentIds)
                       ->where('status', 'completed');
                 })->distinct()->count()
             ]
@@ -879,16 +880,32 @@ class DashboardController extends Controller
             ], 404);
         }
 
-        // Historique : cours terminés et annulés
-        $lessons = Lesson::with([
-                'teacher.user', 'courseType', 'location', 'club',
-                'student.user', 'students.user',
-                'subscriptionInstances.students.user',
-            ])
+        // Historique : terminés, annulés, et cours actifs tombant un jour de fermeture club.
+        $closureDayService = app(ClubClosureDayService::class);
+        $relations = [
+            'teacher.user', 'courseType', 'location', 'club',
+            'student.user', 'students.user',
+            'subscriptionInstances.students.user',
+        ];
+
+        $standardHistory = Lesson::with($relations)
             ->forParticipantStudents($studentIds)
             ->whereIn('status', ['completed', 'cancelled'])
-            ->orderBy('start_time', 'desc')
             ->get();
+
+        $closureHistoryQuery = Lesson::with($relations)
+            ->forParticipantStudents($studentIds)
+            ->whereIn('status', ['confirmed', 'pending']);
+        $closureDayService->includeOnlyClosedDaysFromQuery($closureHistoryQuery);
+        $closureHistory = $closureHistoryQuery->get();
+
+        $lessons = $standardHistory
+            ->concat($closureHistory)
+            ->unique('id')
+            ->sortByDesc(fn ($lesson) => Carbon::parse($lesson->start_time)->timestamp)
+            ->values();
+
+        $closureDayService->flagLessonsOnClosureDays($lessons);
 
         // Contexte foyer : attribution de chaque cours à l'enfant concerné (cf. getBookings).
         $request->attributes->set('household_student_ids', $studentIds);

--- a/app/Http/Controllers/Api/StudentController.php
+++ b/app/Http/Controllers/Api/StudentController.php
@@ -18,6 +18,7 @@ use Illuminate\Validation\Rule;
 use App\Notifications\TeacherWelcomeNotification;
 use App\Notifications\StudentWelcomeNotification;
 use App\Services\FamilyLinkService;
+use App\Services\LessonCalendarDate;
 use Carbon\Carbon;
 
 class StudentController extends Controller
@@ -232,7 +233,8 @@ class StudentController extends Controller
                 $courseTypeId = $lesson->course_type_id;
 
                 // Flag d'affichage : le cours tombe un jour de fermeture du club
-                $lesson->is_on_closure_day = $closureDates->has($lessonDate->toDateString());
+                $lessonYmd = LessonCalendarDate::toYmd($lesson->start_time);
+                $lesson->is_on_closure_day = $lessonYmd !== null && $closureDates->has($lessonYmd);
                 
                 // Par défaut, considérer comme couvert (pour les cours passés ou déjà liés à un abonnement)
                 $lesson->subscription_coverage = [

--- a/app/Http/Controllers/Api/Teacher/DashboardController.php
+++ b/app/Http/Controllers/Api/Teacher/DashboardController.php
@@ -12,6 +12,7 @@ use App\Models\Availability;
 use App\Models\Student;
 use App\Models\CourseType;
 use App\Models\Location;
+use App\Services\ClubClosureDayService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 
@@ -42,9 +43,12 @@ class DashboardController extends Controller
 
         // Requête de base pour les leçons du prof
         $lessons = Lesson::where('teacher_id', $teacher->id);
+        $closureDayService = app(ClubClosureDayService::class);
 
         // Stats générales
-        $today_lessons = (clone $lessons)->where('status', 'confirmed')->whereDate('start_time', $now->toDateString())->count();
+        $todayLessonsQuery = (clone $lessons)->where('status', 'confirmed')->whereDate('start_time', $now->toDateString());
+        $closureDayService->excludeClosedDaysFromQuery($todayLessonsQuery);
+        $today_lessons = $todayLessonsQuery->count();
         $active_students = (clone $lessons)->whereIn('status', ['confirmed', 'completed'])->distinct('student_id')->count('student_id');
         $monthly_earnings = (clone $lessons)->where('status', 'completed')->whereBetween('start_time', [$startOfMonth, $endOfMonth])->sum('price');
 
@@ -52,7 +56,9 @@ class DashboardController extends Controller
         $average_rating = 0;
 
         // Stats de la semaine
-        $week_lessons = (clone $lessons)->where('status', 'confirmed')->whereBetween('start_time', [$startOfWeek, $endOfWeek])->count();
+        $weekLessonsQuery = (clone $lessons)->where('status', 'confirmed')->whereBetween('start_time', [$startOfWeek, $endOfWeek]);
+        $closureDayService->excludeClosedDaysFromQuery($weekLessonsQuery);
+        $week_lessons = $weekLessonsQuery->count();
         $week_hours = (clone $lessons)->where('status', 'completed')->whereBetween('start_time', [$startOfWeek, $endOfWeek])->get()->sum(function ($lesson) {
             return Carbon::parse($lesson->start_time)->diffInMinutes(Carbon::parse($lesson->end_time));
         }) / 60;
@@ -62,11 +68,13 @@ class DashboardController extends Controller
         $new_students = (clone $lessons)->where('created_at', '>=', $now->subMonth())->distinct('student_id')->count('student_id');
 
         // --- Prochains cours ---
-        $upcomingLessons = (clone $lessons)->with('student.user') // Charger l'élève et son utilisateur associé
+        $upcomingLessonsQuery = (clone $lessons)->with('student.user')
             ->where('status', 'confirmed')
             ->where('start_time', '>=', $now)
             ->orderBy('start_time', 'asc')
-            ->limit(5)
+            ->limit(5);
+        $closureDayService->excludeClosedDaysFromQuery($upcomingLessonsQuery);
+        $upcomingLessons = $upcomingLessonsQuery
             ->get()
             ->map(function ($lesson) {
                 return [
@@ -104,6 +112,8 @@ class DashboardController extends Controller
 
         $query = Lesson::with(['student.user', 'students.user', 'courseType', 'location', 'club'])
             ->where('teacher_id', $teacherId);
+
+        app(ClubClosureDayService::class)->excludeClosedDaysFromQuery($query);
 
         if ($request->has('status')) {
             $query->where('status', $request->status);

--- a/app/Http/Resources/PlanningLessonResource.php
+++ b/app/Http/Resources/PlanningLessonResource.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Lesson;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Payload léger pour la grille planning club/enseignant (pas de remaining_* ni nested templates).
+ */
+class PlanningLessonResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Lesson $lesson */
+        $lesson = $this->resource;
+
+        $mapSubscriptionIds = static function ($student): array {
+            if (! $student || ! $student->relationLoaded('subscriptionInstances')) {
+                return [];
+            }
+
+            return $student->subscriptionInstances
+                ->map(static fn ($instance) => ['id' => $instance->id])
+                ->values()
+                ->all();
+        };
+
+        $mapStudent = static function ($student) use ($mapSubscriptionIds): ?array {
+            if (! $student) {
+                return null;
+            }
+
+            return [
+                'id' => $student->id,
+                'user_id' => $student->user_id,
+                'first_name' => $student->first_name,
+                'last_name' => $student->last_name,
+                'phone' => $student->phone,
+                'user' => ($student->relationLoaded('user') && $student->user)
+                    ? [
+                        'id' => $student->user->id,
+                        'name' => $student->user->name,
+                        'phone' => $student->user->phone,
+                    ]
+                    : null,
+                // IDs seuls pour badge 📋 (parité avec ancien hasActiveSubscription)
+                'subscription_instances' => $mapSubscriptionIds($student),
+            ];
+        };
+
+        $subscriptionInstances = [];
+        if ($lesson->relationLoaded('subscriptionInstances')) {
+            foreach ($lesson->subscriptionInstances as $instance) {
+                $subscriptionInstances[] = ['id' => $instance->id];
+            }
+        }
+
+        $teacher = null;
+        if ($lesson->relationLoaded('teacher') && $lesson->teacher) {
+            $teacher = [
+                'id' => $lesson->teacher->id,
+                'user_id' => $lesson->teacher->user_id,
+                'color' => $lesson->teacher->color ?? null,
+                'user' => ($lesson->teacher->relationLoaded('user') && $lesson->teacher->user)
+                    ? [
+                        'id' => $lesson->teacher->user->id,
+                        'name' => $lesson->teacher->user->name,
+                    ]
+                    : null,
+            ];
+        }
+
+        return [
+            'id' => $lesson->id,
+            'teacher_id' => $lesson->teacher_id,
+            'student_id' => $lesson->student_id,
+            'course_type_id' => $lesson->course_type_id,
+            'location_id' => $lesson->location_id,
+            'club_id' => $lesson->club_id,
+            'start_time' => $lesson->start_time,
+            'end_time' => $lesson->end_time,
+            'status' => $lesson->status,
+            'price' => $lesson->price,
+            'notes' => $lesson->notes,
+            'est_legacy' => $lesson->est_legacy,
+            'deduct_from_subscription' => $lesson->deduct_from_subscription,
+            'created_at' => $lesson->created_at,
+            'updated_at' => $lesson->updated_at,
+            'teacher' => $teacher,
+            'student' => ($lesson->relationLoaded('student') && $lesson->student)
+                ? $mapStudent($lesson->student)
+                : null,
+            'students' => ($lesson->relationLoaded('students'))
+                ? $lesson->students->map($mapStudent)->filter()->values()->all()
+                : [],
+            'course_type' => ($lesson->relationLoaded('courseType') && $lesson->courseType)
+                ? [
+                    'id' => $lesson->courseType->id,
+                    'name' => $lesson->courseType->name,
+                ]
+                : null,
+            'courseType' => ($lesson->relationLoaded('courseType') && $lesson->courseType)
+                ? [
+                    'id' => $lesson->courseType->id,
+                    'name' => $lesson->courseType->name,
+                ]
+                : null,
+            'subscription_instances' => $subscriptionInstances,
+            'lesson_recurring_slot' => ($lesson->relationLoaded('lessonRecurringSlot') && $lesson->lessonRecurringSlot)
+                ? [
+                    'id' => $lesson->lessonRecurringSlot->id,
+                    'lesson_id' => $lesson->lessonRecurringSlot->lesson_id,
+                    'recurring_slot_id' => $lesson->lessonRecurringSlot->recurring_slot_id,
+                ]
+                : null,
+        ];
+    }
+}

--- a/app/Http/Resources/StudentLessonCalendarResource.php
+++ b/app/Http/Resources/StudentLessonCalendarResource.php
@@ -39,6 +39,7 @@ class StudentLessonCalendarResource extends JsonResource
             'start_time' => $lesson->start_time?->toIso8601String(),
             'end_time' => $lesson->end_time?->toIso8601String(),
             'status' => $lesson->status,
+            'is_on_closure_day' => (bool) ($lesson->is_on_closure_day ?? false),
             'price' => $lesson->price,
             'payment_status' => $lesson->payment_status,
             'notes' => self::sanitizeNotesForStudent($lesson->notes),

--- a/app/Jobs/NotifyClubClosureRecipientsJob.php
+++ b/app/Jobs/NotifyClubClosureRecipientsJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Models\Club;
 use App\Models\Lesson;
 use App\Models\User;
+use App\Services\LessonCalendarDate;
 use App\Support\FrontendUrl;
 use App\Notifications\ClubClosureNotification;
 use Illuminate\Bus\Queueable;
@@ -34,12 +35,12 @@ class NotifyClubClosureRecipientsJob implements ShouldQueue
             return;
         }
 
-        $lessons = Lesson::query()
+        $lessonsQuery = Lesson::query()
             ->where('club_id', $this->clubId)
-            ->whereDate('start_time', $this->dateYmd)
             ->whereIn('status', ['pending', 'confirmed'])
-            ->with(['teacher.user', 'student.user', 'students.user'])
-            ->get();
+            ->with(['teacher.user', 'student.user', 'students.user']);
+        LessonCalendarDate::whereOnCalendarDate($lessonsQuery, 'start_time', $this->dateYmd);
+        $lessons = $lessonsQuery->get();
 
         $users = collect();
         foreach ($lessons as $lesson) {

--- a/app/Services/ClubClosureDayService.php
+++ b/app/Services/ClubClosureDayService.php
@@ -8,6 +8,8 @@ use App\Models\ClubClosureDay;
 use App\Models\Lesson;
 use App\Models\SubscriptionInstance;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -97,15 +99,81 @@ class ClubClosureDayService
 
     public function shouldSkipSubscriptionConsumption(Lesson $lesson): bool
     {
+        return $this->isLessonOnClosureDay($lesson);
+    }
+
+    public function isLessonOnClosureDay(Lesson $lesson): bool
+    {
         $clubId = $lesson->club_id;
-        if (!$clubId || !$lesson->start_time) {
+        if (! $clubId || ! $lesson->start_time) {
             return false;
         }
 
-        $ymd = Carbon::parse($lesson->start_time)
-            ->timezone(config('app.timezone'))
-            ->format('Y-m-d');
+        $ymd = $this->lessonStartDateYmd($lesson);
 
-        return ClubClosureDay::clubIsClosedOn((int) $clubId, $ymd);
+        return $ymd !== null && ClubClosureDay::clubIsClosedOn((int) $clubId, $ymd);
+    }
+
+    /**
+     * Exclut les cours tombant un jour de fermeture club (même club_id, même règle date que closeDay / whereDate).
+     */
+    public function excludeClosedDaysFromQuery(Builder $query, string $lessonsTable = 'lessons'): void
+    {
+        $lessonDateSql = $this->lessonStartDateSqlExpression($lessonsTable);
+
+        $query->whereNotExists(function ($sub) use ($lessonsTable, $lessonDateSql) {
+            $sub->select(DB::raw(1))
+                ->from('club_closure_days')
+                ->whereColumn('club_closure_days.club_id', "{$lessonsTable}.club_id")
+                ->whereRaw("{$lessonDateSql} = DATE(club_closure_days.closed_on)");
+        });
+    }
+
+    /**
+     * Expression SQL de la date calendaire du cours — alignée sur whereDate('start_time') et lessonStartDateYmd().
+     */
+    private function lessonStartDateSqlExpression(string $lessonsTable): string
+    {
+        return 'DATE('.$lessonsTable.'.start_time)';
+    }
+
+    /**
+     * @param  Collection<int, Lesson>  $lessons
+     * @return Collection<int, Lesson>
+     */
+    public function flagLessonsOnClosureDays(Collection $lessons): Collection
+    {
+        if ($lessons->isEmpty()) {
+            return $lessons;
+        }
+
+        $clubIds = $lessons->pluck('club_id')->filter()->unique()->values()->all();
+
+        $closureDatesByClub = ClubClosureDay::query()
+            ->whereIn('club_id', $clubIds)
+            ->get()
+            ->groupBy('club_id')
+            ->map(fn (Collection $rows) => $rows
+                ->mapWithKeys(fn (ClubClosureDay $row) => [
+                    Carbon::parse($row->closed_on)->toDateString() => true,
+                ]));
+
+        return $lessons->each(function (Lesson $lesson) use ($closureDatesByClub) {
+            $ymd = $this->lessonStartDateYmd($lesson);
+            $clubDates = $closureDatesByClub->get((int) $lesson->club_id);
+            $lesson->is_on_closure_day = $ymd !== null
+                && $clubDates instanceof Collection
+                && $clubDates->has($ymd);
+        });
+    }
+
+    private function lessonStartDateYmd(Lesson $lesson): ?string
+    {
+        if (! $lesson->start_time) {
+            return null;
+        }
+
+        // Aligné sur closeDay() → whereDate('start_time') et excludeClosedDaysFromQuery() → DATE(start_time).
+        return Carbon::parse($lesson->start_time)->toDateString();
     }
 }

--- a/app/Services/ClubClosureDayService.php
+++ b/app/Services/ClubClosureDayService.php
@@ -43,11 +43,11 @@ class ClubClosureDayService
 
             $notify = true;
 
-            $lessons = Lesson::query()
+            $lessonsQuery = Lesson::query()
                 ->where('club_id', $club->id)
-                ->whereDate('start_time', $dateYmd)
-                ->whereIn('status', ['pending', 'confirmed'])
-                ->get();
+                ->whereIn('status', ['pending', 'confirmed']);
+            LessonCalendarDate::whereOnCalendarDate($lessonsQuery, 'start_time', $dateYmd);
+            $lessons = $lessonsQuery->get();
 
             foreach ($lessons as $lesson) {
                 $instances = SubscriptionInstance::query()
@@ -115,26 +115,36 @@ class ClubClosureDayService
     }
 
     /**
-     * Exclut les cours tombant un jour de fermeture club (même club_id, même règle date que closeDay / whereDate).
+     * Exclut les cours tombant un jour de fermeture club (même club_id, même règle date que closeDay).
      */
     public function excludeClosedDaysFromQuery(Builder $query, string $lessonsTable = 'lessons'): void
     {
-        $lessonDateSql = $this->lessonStartDateSqlExpression($lessonsTable);
+        $this->applyClosureDayExistsSubquery($query, $lessonsTable, false);
+    }
 
-        $query->whereNotExists(function ($sub) use ($lessonsTable, $lessonDateSql) {
+    /**
+     * Ne garde que les cours tombant un jour de fermeture club.
+     */
+    public function includeOnlyClosedDaysFromQuery(Builder $query, string $lessonsTable = 'lessons'): void
+    {
+        $this->applyClosureDayExistsSubquery($query, $lessonsTable, true);
+    }
+
+    private function applyClosureDayExistsSubquery(Builder $query, string $lessonsTable, bool $match): void
+    {
+        $lessonDateSql = LessonCalendarDate::sqlDateExpression(
+            "{$lessonsTable}.start_time",
+            $query->getConnection()
+        );
+
+        $method = $match ? 'whereExists' : 'whereNotExists';
+
+        $query->{$method}(function ($sub) use ($lessonsTable, $lessonDateSql) {
             $sub->select(DB::raw(1))
                 ->from('club_closure_days')
                 ->whereColumn('club_closure_days.club_id', "{$lessonsTable}.club_id")
                 ->whereRaw("{$lessonDateSql} = DATE(club_closure_days.closed_on)");
         });
-    }
-
-    /**
-     * Expression SQL de la date calendaire du cours — alignée sur whereDate('start_time') et lessonStartDateYmd().
-     */
-    private function lessonStartDateSqlExpression(string $lessonsTable): string
-    {
-        return 'DATE('.$lessonsTable.'.start_time)';
     }
 
     /**
@@ -169,11 +179,6 @@ class ClubClosureDayService
 
     private function lessonStartDateYmd(Lesson $lesson): ?string
     {
-        if (! $lesson->start_time) {
-            return null;
-        }
-
-        // Aligné sur closeDay() → whereDate('start_time') et excludeClosedDaysFromQuery() → DATE(start_time).
-        return Carbon::parse($lesson->start_time)->toDateString();
+        return LessonCalendarDate::toYmd($lesson->start_time);
     }
 }

--- a/app/Services/CommissionCalculationService.php
+++ b/app/Services/CommissionCalculationService.php
@@ -625,18 +625,14 @@ class CommissionCalculationService
         foreach ($query->get(['club_id', 'closed_on']) as $row) {
             $closedKeys[$row->club_id.'|'.$row->closed_on->format('Y-m-d')] = true;
         }
-        $tz = (string) config(
-            'bookyourcoach.club_daily_planning_insight.timezone',
-            config('app.timezone')
-        );
 
-        return $lessons->filter(function (Lesson $lesson) use ($closedKeys, $tz) {
+        return $lessons->filter(function (Lesson $lesson) use ($closedKeys) {
             if (! $lesson->club_id || ! $lesson->start_time) {
                 return true;
             }
-            $ymd = $lesson->start_time->copy()->timezone((string) $tz)->format('Y-m-d');
+            $ymd = LessonCalendarDate::toYmd($lesson->start_time);
 
-            return empty($closedKeys[$lesson->club_id.'|'.$ymd]);
+            return $ymd !== null && empty($closedKeys[$lesson->club_id.'|'.$ymd]);
         })->values();
     }
 
@@ -709,17 +705,16 @@ class CommissionCalculationService
         array &$linesByTeacher,
         bool $appendDetailLines
     ): void {
-        $tz = (string) config(
-            'bookyourcoach.club_daily_planning_insight.timezone',
-            config('app.timezone')
-        );
         $byTeacherDay = [];
         foreach ($lessons as $lesson) {
             if (! $lesson->teacher_id || ! $lesson->start_time) {
                 continue;
             }
             $tid = (int) $lesson->teacher_id;
-            $day = $lesson->start_time->copy()->timezone((string) $tz)->format('Y-m-d');
+            $day = LessonCalendarDate::toYmd($lesson->start_time);
+            if ($day === null) {
+                continue;
+            }
             $byTeacherDay[$tid][$day][] = $lesson;
         }
 

--- a/app/Services/LegacyRecurringSlotService.php
+++ b/app/Services/LegacyRecurringSlotService.php
@@ -276,7 +276,7 @@ class LegacyRecurringSlotService
             return null;
         }
 
-        $closureDateYmd = $startTime->copy()->timezone(config('app.timezone'))->format('Y-m-d');
+        $closureDateYmd = LessonCalendarDate::toYmd($startTime);
         if (\App\Models\ClubClosureDay::clubIsClosedOn((int) $lastLesson->club_id, $closureDateYmd)) {
             Log::info('Lesson non générée : jour de fermeture club (legacy récurrence)', [
                 'recurring_slot_id' => $recurringSlot->id,
@@ -428,7 +428,7 @@ class LegacyRecurringSlotService
         }
 
         $clubId = (int) ($recurringSlot->subscriptionInstance?->subscription?->club_id ?? 0);
-        if ($clubId > 0 && ClubClosureDay::clubIsClosedOn($clubId, $dayStart->format('Y-m-d'))) {
+        if ($clubId > 0 && ClubClosureDay::clubIsClosedOn($clubId, LessonCalendarDate::toYmd($dayStart) ?? '')) {
             return [
                 'success' => false,
                 'lesson' => null,

--- a/app/Services/LessonCalendarDate.php
+++ b/app/Services/LessonCalendarDate.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Date calendaire d'un cours (jour local club) — source unique pour fermetures, filtres API et récurrence.
+ */
+class LessonCalendarDate
+{
+    public static function timezone(): string
+    {
+        return (string) config(
+            'bookyourcoach.lesson_calendar.timezone',
+            config('bookyourcoach.club_daily_planning_insight.timezone', config('app.timezone'))
+        );
+    }
+
+    public static function dbStorageTimezone(): string
+    {
+        return (string) config(
+            'bookyourcoach.lesson_calendar.db_storage_timezone',
+            config('app.timezone')
+        );
+    }
+
+    public static function toYmd(Carbon|string|null $startTime): ?string
+    {
+        if ($startTime === null || $startTime === '') {
+            return null;
+        }
+
+        return Carbon::parse($startTime)
+            ->timezone(self::timezone())
+            ->toDateString();
+    }
+
+    /**
+     * Expression SQL DATE(...) alignée sur {@see toYmd()} pour les requêtes (exclude / include closure).
+     */
+    public static function sqlDateExpression(string $qualifiedColumn, ?Connection $connection = null): string
+    {
+        $driver = $connection?->getDriverName() ?? 'mysql';
+
+        if ($driver === 'sqlite') {
+            return "DATE({$qualifiedColumn})";
+        }
+
+        $storageTz = self::dbStorageTimezone();
+        $calendarTz = self::timezone();
+
+        if ($storageTz === $calendarTz) {
+            return "DATE({$qualifiedColumn})";
+        }
+
+        return "DATE(CONVERT_TZ({$qualifiedColumn}, '{$storageTz}', '{$calendarTz}'))";
+    }
+
+    /**
+     * Filtre les lignes dont la date calendaire du cours correspond à $dateYmd (même règle que {@see toYmd()}).
+     */
+    public static function whereOnCalendarDate(Builder $query, string $qualifiedColumn, string $dateYmd): void
+    {
+        $connection = $query->getConnection();
+        $storageTz = self::dbStorageTimezone();
+        $calendarTz = self::timezone();
+
+        if ($storageTz !== $calendarTz && $connection->getDriverName() === 'sqlite') {
+            $start = Carbon::parse($dateYmd, $calendarTz)->startOfDay()->timezone($storageTz);
+            $end = Carbon::parse($dateYmd, $calendarTz)->endOfDay()->timezone($storageTz);
+            $query->whereBetween($qualifiedColumn, [
+                $start->format('Y-m-d H:i:s'),
+                $end->format('Y-m-d H:i:s'),
+            ]);
+
+            return;
+        }
+
+        $expr = self::sqlDateExpression($qualifiedColumn, $connection);
+        $query->whereRaw("{$expr} = ?", [$dateYmd]);
+    }
+}

--- a/app/Services/LessonReactivationService.php
+++ b/app/Services/LessonReactivationService.php
@@ -75,6 +75,12 @@ class LessonReactivationService
             $lesson,
             &$reactivatedIds
         ) {
+            // Capturer le créneau avant réactivation : consumeLesson peut vider
+            // cancelled_subscription_instance_ids sur le même modèle Lesson.
+            $slotToRestore = $restoreRecurring
+                ? $this->findMatchingRecurringSlot($lesson)
+                : null;
+
             foreach ($lessons as $lessonToReactivate) {
                 $this->reactivateOneLesson(
                     $lessonToReactivate,
@@ -86,8 +92,8 @@ class LessonReactivationService
                 $reactivatedIds[] = $lessonToReactivate->id;
             }
 
-            if ($restoreRecurring) {
-                $this->restoreRecurringSlotIfNeeded($lesson);
+            if ($slotToRestore && $slotToRestore->status === 'cancelled') {
+                $slotToRestore->reactivate('Réactivé avec les cours annulés');
             }
         });
 
@@ -281,22 +287,44 @@ class LessonReactivationService
     {
         $lesson->loadMissing('subscriptionInstances');
         $start = Carbon::parse($lesson->start_time);
-        $dayOfWeek = $start->dayOfWeek;
+        $dayOfWeek = (int) $start->dayOfWeek;
         $timeStr = $start->format('H:i:s');
+        $timeHm = $start->format('H:i');
 
         $instanceIds = $lesson->cancelled_subscription_instance_ids
             ?? $lesson->subscriptionInstances->pluck('id')->all();
 
-        if ($instanceIds === [] || ! $lesson->student_id || ! $lesson->teacher_id) {
+        if (! is_array($instanceIds)) {
+            $instanceIds = [];
+        }
+        $instanceIds = array_values(array_filter(array_map('intval', $instanceIds)));
+
+        $studentId = $lesson->student_id
+            ?? $this->lessonDeletionService->resolveParticipantStudentId($lesson);
+
+        if ($instanceIds === [] || ! $studentId || ! $lesson->teacher_id) {
             return null;
         }
 
-        return SubscriptionRecurringSlot::query()
+        $candidates = SubscriptionRecurringSlot::query()
             ->whereIn('subscription_instance_id', $instanceIds)
-            ->where('student_id', $lesson->student_id)
+            ->where('student_id', $studentId)
             ->where('teacher_id', $lesson->teacher_id)
             ->where('day_of_week', $dayOfWeek)
-            ->whereRaw('TIME(start_time) = ?', [$timeStr])
-            ->first();
+            ->get();
+
+        return $candidates->first(function (SubscriptionRecurringSlot $slot) use ($timeStr, $timeHm) {
+            $raw = $slot->getAttributes()['start_time'] ?? $slot->start_time;
+            if ($raw instanceof Carbon) {
+                $slotTime = $raw->format('H:i:s');
+            } else {
+                $slotTime = substr((string) $raw, 0, 8);
+            }
+
+            return $slotTime === $timeStr
+                || substr($slotTime, 0, 5) === $timeHm
+                || (string) $raw === $timeStr
+                || (string) $raw === $timeHm;
+        });
     }
 }

--- a/app/Services/RecurringSlotService.php
+++ b/app/Services/RecurringSlotService.php
@@ -168,7 +168,7 @@ class RecurringSlotService
         );
         $endTime = $startTime->copy()->addMinutes($recurringSlot->duration_minutes);
 
-        $closureDateYmd = $startTime->copy()->timezone(config('app.timezone'))->format('Y-m-d');
+        $closureDateYmd = LessonCalendarDate::toYmd($startTime);
         if (\App\Models\ClubClosureDay::clubIsClosedOn((int) $recurringSlot->club_id, $closureDateYmd)) {
             Log::info('Lesson non générée : jour de fermeture club (récurrence)', [
                 'recurring_slot_id' => $recurringSlot->id,

--- a/config/bookyourcoach.php
+++ b/config/bookyourcoach.php
@@ -45,4 +45,15 @@ return [
         'max_alternatives_returned' => (int) env('RECURRING_PLANNING_ADVICE_MAX_ALTERNATIVES', 12),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Date calendaire des cours (fermeture club, filtres planning, récurrence)
+    |--------------------------------------------------------------------------
+    */
+    'lesson_calendar' => [
+        'timezone' => env('LESSON_CALENDAR_TIMEZONE', env('CLUB_DAILY_PLANNING_INSIGHT_TIMEZONE', 'Europe/Paris')),
+        // Par défaut identique au calendrier club : évite CONVERT_TZ MySQL si stockage naïf local.
+        'db_storage_timezone' => env('LESSON_DB_STORAGE_TIMEZONE', env('LESSON_CALENDAR_TIMEZONE', env('CLUB_DAILY_PLANNING_INSIGHT_TIMEZONE', 'Europe/Paris'))),
+    ],
+
 ];

--- a/frontend/components/StudentCalendar.vue
+++ b/frontend/components/StudentCalendar.vue
@@ -11,7 +11,7 @@
             class="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
             @change="loadCalendarEvents"
           >
-          Afficher les cours annulés
+          Afficher les cours annulés ou fermés
         </label>
         <button @click="toggleView('month')" 
           :class="['min-h-[44px] min-w-[44px] px-3 py-2 rounded-md text-sm font-medium transition-colors', 
@@ -89,14 +89,10 @@
             <div class="space-y-0.5 sm:space-y-1">
               <div v-for="event in day.events" :key="event.id" 
                 @click="selectEvent(event)"
-                :class="['text-xs p-1.5 sm:p-2 rounded cursor-pointer hover:opacity-90 transition-opacity min-h-[32px] flex flex-col justify-center leading-tight', 
-                  event.status === 'confirmed' ? 'bg-blue-100 text-blue-800' : 
-                  event.status === 'pending' ? 'bg-yellow-100 text-yellow-800' :
-                  event.status === 'cancelled' ? 'bg-red-100 text-red-800' :
-                  'bg-gray-100 text-gray-800']"
+                :class="['text-xs p-1.5 sm:p-2 rounded cursor-pointer hover:opacity-90 transition-opacity min-h-[32px] flex flex-col justify-center leading-tight', eventCardClass(event)]"
                 :title="`${event.title} – ${formatTime(event.start)}`">
                 <span class="font-medium whitespace-nowrap">{{ formatTime(event.start) }}</span>
-                <span class="block truncate mt-0.5" :class="event.status === 'cancelled' ? 'line-through' : ''">{{ event.title }}</span>
+                <span class="block truncate mt-0.5" :class="isNonMaintainedEvent(event) ? 'line-through' : ''">{{ event.title }}</span>
               </div>
             </div>
           </div>
@@ -120,13 +116,9 @@
                 v-for="event in dayInfo.events"
                 :key="event.id"
                 @click="selectEvent(event)"
-                :class="['p-3 rounded-lg cursor-pointer hover:opacity-90 transition-opacity',
-                  event.status === 'confirmed' ? 'bg-blue-100 text-blue-800' :
-                  event.status === 'pending' ? 'bg-yellow-100 text-yellow-800' :
-                  event.status === 'cancelled' ? 'bg-red-100 text-red-800' :
-                  'bg-gray-100 text-gray-800']"
+                :class="['p-3 rounded-lg cursor-pointer hover:opacity-90 transition-opacity', eventCardClass(event)]"
               >
-                <p class="font-medium text-sm" :class="event.status === 'cancelled' ? 'line-through' : ''">{{ event.title }}</p>
+                <p class="font-medium text-sm" :class="isNonMaintainedEvent(event) ? 'line-through' : ''">{{ event.title }}</p>
                 <p class="text-xs mt-0.5 text-gray-600">{{ formatTime(event.start) }} – {{ formatTime(event.end) }}</p>
               </div>
               <p v-if="dayInfo.events.length === 0" class="text-xs text-gray-400 py-2">Aucun cours</p>
@@ -155,16 +147,12 @@
                   v-for="event in getEventsForHourAndDay(hour, day)"
                   :key="event.id"
                   @click="selectEvent(event)"
-                  :class="['absolute left-1 right-1 p-2 rounded text-xs cursor-pointer hover:opacity-90 transition-opacity overflow-hidden flex flex-col justify-center',
-                    event.status === 'confirmed' ? 'bg-blue-100 text-blue-800' :
-                    event.status === 'pending' ? 'bg-yellow-100 text-yellow-800' :
-                    event.status === 'cancelled' ? 'bg-red-100 text-red-800' :
-                    'bg-gray-100 text-gray-800']"
+                  :class="['absolute left-1 right-1 p-2 rounded text-xs cursor-pointer hover:opacity-90 transition-opacity overflow-hidden flex flex-col justify-center', eventCardClass(event)]"
                   :style="{ top: `${getEventPosition(event, hour)}px`, height: `${getEventHeight(event)}px` }"
                   :title="event.title"
                 >
                   <span class="font-medium">{{ formatTime(event.start) }}</span>
-                  <span class="truncate block" :class="event.status === 'cancelled' ? 'line-through' : ''">{{ event.title }}</span>
+                  <span class="truncate block" :class="isNonMaintainedEvent(event) ? 'line-through' : ''">{{ event.title }}</span>
                 </div>
               </div>
             </div>
@@ -186,13 +174,9 @@
                 :key="event.id"
                 @click="selectEvent(event)"
                 class="min-h-[48px] flex flex-col justify-center"
-                :class="['p-3 sm:p-4 rounded-lg cursor-pointer hover:opacity-90 transition-opacity',
-                  event.status === 'confirmed' ? 'bg-blue-100 text-blue-800 border border-blue-200' : 
-                  event.status === 'pending' ? 'bg-yellow-100 text-yellow-800 border border-yellow-200' :
-                  event.status === 'cancelled' ? 'bg-red-100 text-red-800 border border-red-200' :
-                  'bg-gray-100 text-gray-800 border border-gray-200']"
+                :class="['p-3 sm:p-4 rounded-lg cursor-pointer hover:opacity-90 transition-opacity', eventCardClass(event, true)]"
               >
-                <p class="font-medium" :class="event.status === 'cancelled' ? 'line-through' : ''">{{ event.title }}</p>
+                <p class="font-medium" :class="isNonMaintainedEvent(event) ? 'line-through' : ''">{{ event.title }}</p>
                 <p class="text-xs mt-1 text-gray-600">{{ formatTime(event.start) }} – {{ formatTime(event.end) }}</p>
               </div>
             </div>
@@ -240,14 +224,15 @@
             <span class="text-sm font-medium text-gray-500">Statut:</span>
             <span 
               :class="{
-                'bg-green-100 text-green-800': selectedEvent.status === 'confirmed',
+                'bg-green-100 text-green-800': selectedEvent.status === 'confirmed' && !selectedEvent.is_on_closure_day,
                 'bg-yellow-100 text-yellow-800': selectedEvent.status === 'pending',
                 'bg-gray-100 text-gray-800': selectedEvent.status === 'completed',
-                'bg-red-100 text-red-800': selectedEvent.status === 'cancelled'
+                'bg-red-100 text-red-800': selectedEvent.status === 'cancelled',
+                'bg-orange-100 text-orange-800': selectedEvent.is_on_closure_day,
               }"
               class="ml-2 inline-block px-2 py-1 text-xs font-medium rounded-full"
             >
-              {{ getStatusLabel(selectedEvent.status) }}
+              {{ getStatusLabel(selectedEvent) }}
             </span>
           </div>
           <template v-if="selectedEvent.status === 'cancelled'">
@@ -483,7 +468,11 @@ const formatPrice = (price) => {
   }).format(price)
 }
 
-const getStatusLabel = (status) => {
+const getStatusLabel = (eventOrStatus) => {
+  if (eventOrStatus && typeof eventOrStatus === 'object') {
+    if (eventOrStatus.is_on_closure_day) return 'Fermeture club'
+    return getStatusLabel(eventOrStatus.status)
+  }
   const labels = {
     'confirmed': 'Confirmé',
     'pending': 'En attente',
@@ -491,7 +480,26 @@ const getStatusLabel = (status) => {
     'cancelled': 'Annulé',
     'available': 'Disponible'
   }
-  return labels[status] || status
+  return labels[eventOrStatus] || eventOrStatus
+}
+
+const isNonMaintainedEvent = (event) => event.status === 'cancelled' || Boolean(event.is_on_closure_day)
+
+const eventCardClass = (event, withBorder = false) => {
+  const border = withBorder ? ' border' : ''
+  if (event.is_on_closure_day) {
+    return `${withBorder ? 'bg-orange-100 text-orange-800 border-orange-200' : 'bg-orange-100 text-orange-800'}${border}`
+  }
+  if (event.status === 'confirmed') {
+    return `${withBorder ? 'bg-blue-100 text-blue-800 border-blue-200' : 'bg-blue-100 text-blue-800'}${border}`
+  }
+  if (event.status === 'pending') {
+    return `${withBorder ? 'bg-yellow-100 text-yellow-800 border-yellow-200' : 'bg-yellow-100 text-yellow-800'}${border}`
+  }
+  if (event.status === 'cancelled') {
+    return `${withBorder ? 'bg-red-100 text-red-800 border-red-200' : 'bg-red-100 text-red-800'}${border}`
+  }
+  return `${withBorder ? 'bg-gray-100 text-gray-800 border-gray-200' : 'bg-gray-100 text-gray-800'}${border}`
 }
 
 
@@ -582,7 +590,7 @@ const loadCalendarEvents = async () => {
       events.value = lessons
         .filter(lesson => {
           if (!lesson.start_time) return false
-          if (!showCancelled.value && lesson.status === 'cancelled') return false
+          if (!showCancelled.value && (lesson.status === 'cancelled' || lesson.is_on_closure_day)) return false
           return true
         })
         .map(lesson => ({
@@ -594,6 +602,7 @@ const loadCalendarEvents = async () => {
           location: lesson.location,
           price: lesson.price,
           status: lesson.status,
+          is_on_closure_day: Boolean(lesson.is_on_closure_day),
           description: lesson.notes,
           notes: lesson.notes,
           course_type: lesson.course_type || lesson.courseType,

--- a/frontend/components/planning/PlanningParticipantInfoModal.vue
+++ b/frontend/components/planning/PlanningParticipantInfoModal.vue
@@ -73,10 +73,10 @@
                 {{ quarterPeriodLabel }}
               </p>
               <p
-                v-if="type === 'student' && cancelledLessonsCount > 0"
+                v-if="type === 'student' && nonMaintainedLessonsCount > 0"
                 class="text-xs text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2"
               >
-                {{ cancelledLessonsCount }} cours annulé{{ cancelledLessonsCount > 1 ? 's' : '' }} ou supprimé{{ cancelledLessonsCount > 1 ? 's' : '' }} sur la période
+                {{ nonMaintainedLessonsCount }} cours non maintenu{{ nonMaintainedLessonsCount > 1 ? 's' : '' }} ou supprimé{{ nonMaintainedLessonsCount > 1 ? 's' : '' }} sur la période
               </p>
               <p v-if="displayedLessons.length === 0" class="text-sm text-gray-500 py-8 text-center bg-gray-50 rounded-lg border border-gray-200">
                 {{ type === 'student' ? 'Aucun cours sur ce trimestre.' : 'Aucun cours prévu sur cette période.' }}
@@ -90,7 +90,7 @@
                 >
                   <div class="flex flex-wrap items-start justify-between gap-2">
                     <div class="min-w-0">
-                      <p class="font-medium text-gray-900">
+                      <p class="font-medium text-gray-900" :class="lessonIsNonMaintained(lesson) ? 'line-through' : ''">
                         {{ formatLessonDate(lesson.start_time) }}
                         <span class="text-gray-500 font-normal">
                           · {{ formatLessonTime(lesson.start_time) }} – {{ formatLessonTime(lesson.end_time) }}
@@ -277,10 +277,14 @@ const displayedLessons = computed(() => {
     .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
 })
 
-const cancelledLessonsCount = computed(() => {
+const nonMaintainedLessonsCount = computed(() => {
   if (props.type !== 'student') return 0
-  return displayedLessons.value.filter((lesson) => lesson.status === 'cancelled' || lesson.deleted_at).length
+  return displayedLessons.value.filter((lesson) => lessonIsNonMaintained(lesson) || lesson.deleted_at).length
 })
+
+function lessonIsNonMaintained(lesson: { status?: string; is_on_closure_day?: boolean }) {
+  return lesson.status === 'cancelled' || Boolean(lesson.is_on_closure_day)
+}
 
 const contactRows = computed(() => {
   if (props.type === 'student') {

--- a/frontend/components/planning/SlotsList.vue
+++ b/frontend/components/planning/SlotsList.vue
@@ -125,12 +125,6 @@
                     title="Modifier">
                     ✏️
                   </button>
-                  <button 
-                    @click.stop="$emit('delete-slot', slot)"
-                    class="flex-1 px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded transition-colors"
-                    title="Supprimer">
-                    🗑️
-                  </button>
                 </div>
               </div>
               
@@ -194,11 +188,6 @@
                 class="flex-1 px-3 py-1.5 text-xs text-blue-600 bg-blue-50 hover:bg-blue-100 rounded-lg transition-colors font-medium">
                 ✏️ Modifier
               </button>
-              <button 
-                @click.stop="$emit('delete-slot', slot)"
-                class="flex-1 px-3 py-1.5 text-xs text-red-600 bg-red-50 hover:bg-red-100 rounded-lg transition-colors font-medium">
-                🗑️ Supprimer
-              </button>
             </div>
           </div>
         </div>
@@ -252,7 +241,6 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   'create-slot': []
   'edit-slot': [slot: OpenSlot]
-  'delete-slot': [slot: OpenSlot]
   'select-slot': [slot: OpenSlot]
 }>()
 
@@ -290,8 +278,8 @@ function getSlotsByDay(dayOfWeek: number): OpenSlot[] {
 
 function handleSlotClick(slot: OpenSlot) {
   emit('select-slot', slot)
-  // Ne pas fermer le panneau : les actions Modifier / Supprimer sont dans la zone dépliée ;
-  // les refermer provoquait la « disparition » des boutons après sélection d’un créneau.
+  // Ne pas fermer le panneau : l'action Modifier reste dans la zone dépliée ;
+  // la refermer provoquait la « disparition » du bouton après sélection d’un créneau.
   // Sur très petit écran, replier libère de la place une fois le créneau choisi.
   if (typeof window !== 'undefined' && window.matchMedia('(max-width: 767px)').matches) {
     isOpen.value = false

--- a/frontend/components/planning/SlotsList.vue
+++ b/frontend/components/planning/SlotsList.vue
@@ -92,6 +92,7 @@
               <div 
                 v-for="slot in getSlotsByDay((day) % 7)" 
                 :key="slot.id"
+                data-testid="open-slot"
                 @click="handleSlotClick(slot)"
                 class="border-2 rounded-lg p-2 cursor-pointer transition-all hover:shadow-md"
                 :class="[
@@ -147,6 +148,7 @@
           <div 
             v-for="slot in slots" 
             :key="slot.id"
+            data-testid="open-slot"
             @click="handleSlotClick(slot)"
             class="border-2 rounded-lg p-3 cursor-pointer transition-all hover:shadow-md"
             :class="[

--- a/frontend/composables/planning/usePlanningLessonIndex.ts
+++ b/frontend/composables/planning/usePlanningLessonIndex.ts
@@ -1,0 +1,93 @@
+/**
+ * Indexation / filtrage des cours pour la grille planning club.
+ * Extrait de planning.vue pour tests unitaires anti-régression.
+ */
+
+export function toLocalYmd(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+export function toLocalHm(d: Date): string {
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+export type PlanningIndexLesson = {
+  start_time?: string | null
+  is_recurring_placeholder?: boolean
+  subscription_instances?: unknown[] | null
+  student?: { subscription_instances?: unknown[] | null } | null
+  students?: Array<{ subscription_instances?: unknown[] | null }> | null
+}
+
+/**
+ * Index O(1) par jour local (YYYY-MM-DD).
+ */
+export function buildLessonsByLocalDate<T extends { start_time?: string | null }>(
+  lessons: T[],
+): Map<string, T[]> {
+  const map = new Map<string, T[]>()
+  for (const lesson of lessons) {
+    if (!lesson?.start_time) continue
+    const d = new Date(lesson.start_time)
+    if (Number.isNaN(d.getTime())) continue
+    const key = toLocalYmd(d)
+    const bucket = map.get(key)
+    if (bucket) {
+      bucket.push(lesson)
+    } else {
+      map.set(key, [lesson])
+    }
+  }
+  return map
+}
+
+export type OpenSlotTimeWindow = {
+  day_of_week: number
+  start_time: string
+  end_time: string
+}
+
+/**
+ * Filtre créneau (jour + plage horaire) sur une liste déjà bornée éventuellement par date.
+ */
+export function filterLessonsForOpenSlot<T extends { start_time: string }>(
+  candidates: T[],
+  slot: OpenSlotTimeWindow,
+  formatTime: (time: string) => string,
+): T[] {
+  const slotStartTime = formatTime(slot.start_time)
+  const slotEndTime = formatTime(slot.end_time)
+
+  return candidates.filter((lesson) => {
+    const lessonDate = new Date(lesson.start_time)
+    if (Number.isNaN(lessonDate.getTime())) return false
+    const lessonDay = lessonDate.getDay()
+    const lessonTime = toLocalHm(lessonDate)
+    return lessonDay === slot.day_of_week
+      && lessonTime >= slotStartTime
+      && lessonTime < slotEndTime
+  })
+}
+
+/**
+ * Badge 📋 : parité avec hasActiveSubscription (pivot lesson + abo actifs élève).
+ */
+export function lessonHasActiveSubscriptionBadge(lesson: PlanningIndexLesson | null | undefined): boolean {
+  if (!lesson) return false
+  if (lesson.is_recurring_placeholder) return true
+  if (Array.isArray(lesson.subscription_instances) && lesson.subscription_instances.length > 0) {
+    return true
+  }
+  if (lesson.student?.subscription_instances && lesson.student.subscription_instances.length > 0) {
+    return true
+  }
+  if (Array.isArray(lesson.students)) {
+    return lesson.students.some(
+      (student) => Array.isArray(student.subscription_instances) && student.subscription_instances.length > 0,
+    )
+  }
+  return false
+}

--- a/frontend/pages/club/planning.vue
+++ b/frontend/pages/club/planning.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gray-50 p-8">
+  <div class="min-h-screen bg-gray-50 p-8" data-testid="planning-view">
     <div class="max-w-7xl mx-auto">
     <!-- Header -->
       <div class="mb-8 flex flex-wrap items-center justify-between gap-4">
@@ -31,7 +31,7 @@
         <DisciplinesList :disciplines="activeDisciplines" />
         
         <!-- Bloc 2: Gestion des créneaux horaires avec sélection -->
-        <div id="open-slots-section">
+        <div id="open-slots-section" data-testid="open-slots-section">
           <SlotsList 
             ref="slotsListRef"
             :slots="openSlots"
@@ -117,7 +117,7 @@
         </div>
 
         <!-- Bloc 3: Cours programmés (filtrés par créneau sélectionné) -->
-        <div class="bg-white shadow rounded-lg p-6">
+        <div class="bg-white shadow rounded-lg p-6" data-testid="scheduled-lessons-section">
           <div class="mb-4">
             <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
               <div>
@@ -1571,6 +1571,12 @@ import {
   participantDisplayNameFromStudent,
   participantDisplayNameFromTeacher,
 } from '~/composables/planning/usePlanningParticipant'
+import {
+  buildLessonsByLocalDate,
+  filterLessonsForOpenSlot,
+  lessonHasActiveSubscriptionBadge,
+  toLocalYmd,
+} from '~/composables/planning/usePlanningLessonIndex'
 
 // Composable pour les toasts
 const { success, error: showError, warning } = useToast()
@@ -1844,34 +1850,8 @@ const pendingCertificateStudents = computed(() => {
   return list
 })
 
-function toLocalYmd(d: Date): string {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
-}
-
-function toLocalHm(d: Date): string {
-  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-}
-
 /** Index O(1) par jour local — évite de rescanner toute la fenêtre 8 sem. à chaque filtre. */
-const lessonsByLocalDate = computed(() => {
-  const map = new Map<string, Lesson[]>()
-  for (const lesson of lessons.value) {
-    if (!lesson?.start_time) continue
-    const d = new Date(lesson.start_time as string)
-    if (Number.isNaN(d.getTime())) continue
-    const key = toLocalYmd(d)
-    const bucket = map.get(key)
-    if (bucket) {
-      bucket.push(lesson)
-    } else {
-      map.set(key, [lesson])
-    }
-  }
-  return map
-})
+const lessonsByLocalDate = computed(() => buildLessonsByLocalDate(lessons.value))
 
 // Cours filtrés par créneau sélectionné ET par date
 const filteredLessons = computed(() => {
@@ -1881,21 +1861,11 @@ const filteredLessons = computed(() => {
   }
 
   const slot = selectedSlot.value
-  const slotStartTime = formatTime(slot.start_time)
-  const slotEndTime = formatTime(slot.end_time)
-
   const candidates = selectedDate.value
     ? (lessonsByLocalDate.value.get(toLocalYmd(selectedDate.value)) ?? [])
     : lessons.value
 
-  return candidates.filter((lesson) => {
-    const lessonDate = new Date(lesson.start_time)
-    const lessonDay = lessonDate.getDay()
-    const lessonTime = toLocalHm(lessonDate)
-    const dayMatch = lessonDay === slot.day_of_week
-    const timeMatch = lessonTime >= slotStartTime && lessonTime < slotEndTime
-    return dayMatch && timeMatch
-  })
+  return filterLessonsForOpenSlot(candidates, slot, formatTime)
 })
 
 /**
@@ -5015,29 +4985,8 @@ function getLessonStudentTelHref(lesson: Lesson | null): string | null {
   return `tel:${cleaned}`
 }
 
-// Fonction pour vérifier si un cours a un abonnement actif
 function hasActiveSubscription(lesson: Lesson | null): boolean {
-  if (!lesson) return false
-  if (lesson.is_recurring_placeholder) return true
-
-  // Lien abo sur le cours (payload planning slim : subscription_instances: [{id}])
-  if ((lesson as any).subscription_instances?.length > 0) {
-    return true
-  }
-  
-  // Vérifier l'élève principal (payload complet historique)
-  if (lesson.student?.subscription_instances && lesson.student.subscription_instances.length > 0) {
-    return true
-  }
-  
-  // Vérifier les élèves de la relation many-to-many
-  if (lesson.students && Array.isArray(lesson.students)) {
-    return lesson.students.some((student: any) => 
-      student.subscription_instances && student.subscription_instances.length > 0
-    )
-  }
-  
-  return false
+  return lessonHasActiveSubscriptionBadge(lesson as any)
 }
 
 

--- a/frontend/pages/club/planning.vue
+++ b/frontend/pages/club/planning.vue
@@ -38,7 +38,6 @@
             :selected-slot-id="selectedSlot?.id"
             @create-slot="openSlotModal()"
             @edit-slot="openSlotModal"
-            @delete-slot="(slot) => deleteSlot(slot.id)"
             @select-slot="handleSlotSelection"
           />
         </div>
@@ -1006,15 +1005,26 @@
           </div>
 
                 <!-- Boutons -->
-                <div class="flex justify-end gap-3 mt-6 pt-4 border-t">
-                  <button type="button" @click="closeSlotModal"
-                          class="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-              Annuler
-            </button>
-                  <button type="submit" :disabled="saving"
-                          class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50">
-                    {{ saving ? 'Enregistrement...' : 'Enregistrer' }}
-            </button>
+                <div class="flex items-center justify-between gap-3 mt-6 pt-4 border-t">
+                  <button
+                    v-if="editingSlot"
+                    type="button"
+                    @click="deleteSlotFromModal"
+                    class="px-4 py-2 text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors"
+                  >
+                    Supprimer
+                  </button>
+                  <div v-else></div>
+                  <div class="flex gap-3">
+                    <button type="button" @click="closeSlotModal"
+                            class="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                      Annuler
+                    </button>
+                    <button type="submit" :disabled="saving"
+                            class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50">
+                      {{ saving ? 'Enregistrement...' : 'Enregistrer' }}
+                    </button>
+                  </div>
           </div>
         </form>
             </div>
@@ -3399,6 +3409,11 @@ async function deleteSlot(id: number) {
     const { $api } = useNuxtApp()
     await $api.delete(`/club/open-slots/${id}`)
     planningDevLog('✅ Créneau supprimé')
+
+    if (selectedSlot.value?.id === id) {
+      selectedSlot.value = null
+    }
+    closeSlotModal()
     
     // Recharger la liste
     await loadOpenSlots()
@@ -3415,6 +3430,11 @@ async function deleteSlot(id: number) {
     
     showError(errorMessage, 'Erreur de suppression')
   }
+}
+
+async function deleteSlotFromModal() {
+  if (!editingSlot.value?.id) return
+  await deleteSlot(editingSlot.value.id)
 }
 
 async function openCreateLessonModal(slot?: OpenSlot, customTime?: string, explicitDate?: string) {

--- a/frontend/pages/club/planning.vue
+++ b/frontend/pages/club/planning.vue
@@ -418,21 +418,21 @@
                     class="border-2 rounded-lg p-3 transition-all bg-white min-w-0 max-w-full flex flex-col overflow-hidden"
                     :class="[
                       getLessonBorderClass(lesson),
-                      planningLessonHasTeacherParallelConflict(lesson) ? 'ring-2 ring-red-600 ring-offset-2' : '',
+                      getPlanningGridMeta(lesson)?.hasTeacherConflict ? 'ring-2 ring-red-600 ring-offset-2' : '',
                       isSelectedDateClosure && lesson.status !== 'cancelled'
                         ? 'opacity-55 grayscale pointer-events-none cursor-not-allowed'
                         : lesson.is_recurring_placeholder
                           ? 'cursor-default hover:shadow-md'
                           : 'cursor-pointer hover:shadow-lg hover:scale-[1.02]',
                     ]"
-                    :style="getLessonCardStyle(lesson)"
+                    :style="getPlanningGridMeta(lesson)?.cardStyle"
                     @click="openLessonModal(lesson)">
                     
                     <!-- Type de cours et statut -->
                     <div class="flex items-start justify-between gap-2 mb-2">
                       <div class="flex items-start gap-1.5 min-w-0 flex-1">
                         <span
-                          v-if="planningLessonHasTeacherParallelConflict(lesson)"
+                          v-if="getPlanningGridMeta(lesson)?.hasTeacherConflict"
                           class="shrink-0 mt-0.5 text-red-600"
                           title="Sens interdit : ce coach a un autre cours en parallèle sur cette plage. Corrigez l’horaire ou changez d’enseignant."
                         >
@@ -442,7 +442,7 @@
                           </svg>
                         </span>
                         <span
-                          v-if="planningLessonOverlapsRecurringSeries(lesson)"
+                          v-if="getPlanningGridMeta(lesson)?.overlapsRecurring"
                           class="shrink-0 mt-0.5 text-violet-600"
                           title="Série récurrente (abonnement) — gérer dans Créneaux récurrents"
                         >
@@ -470,7 +470,7 @@
                               {{ recurringPlaceholderSummaryLine(lesson) }}
                             </p>
                             <p
-                              v-if="isPlaceholderFromCancelledLesson(lesson)"
+                              v-if="getPlanningGridMeta(lesson)?.fromCancelled"
                               class="mt-1.5 mb-0 text-xs font-medium text-amber-800 leading-snug"
                             >
                               Séance annulée : cet emplacement peut accueillir un cours ponctuel.
@@ -505,14 +505,14 @@
                         v-if="resolveLessonPrimaryStudentId(lesson)"
                         type="button"
                         class="font-medium truncate text-left text-blue-700 hover:text-blue-900 hover:underline underline-offset-2 min-w-0"
-                        :title="`Voir la fiche de ${getLessonStudents(lesson)}`"
+                        :title="`Voir la fiche de ${getPlanningGridMeta(lesson)?.studentsLabel}`"
                         @click.stop="openStudentInfoFromLesson(lesson)"
                       >
-                        {{ getLessonStudents(lesson) }}
+                        {{ getPlanningGridMeta(lesson)?.studentsLabel }}
                       </button>
-                      <span v-else class="font-medium truncate">{{ getLessonStudents(lesson) }}</span>
+                      <span v-else class="font-medium truncate">{{ getPlanningGridMeta(lesson)?.studentsLabel }}</span>
                       <span 
-                        v-if="hasActiveSubscription(lesson)"
+                        v-if="getPlanningGridMeta(lesson)?.hasAbo"
                         class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-700 flex-shrink-0"
                         title="Abonnement actif"
                       >
@@ -520,17 +520,17 @@
                       </span>
                     </div>
                     <div
-                      v-if="getLessonStudentPhonesDisplay(lesson)"
+                      v-if="getPlanningGridMeta(lesson)?.phonesDisplay"
                       class="flex items-start gap-1 text-xs text-gray-600 mb-1 min-w-0"
                     >
                       <span class="shrink-0" aria-hidden="true">📞</span>
                       <a
-                        v-if="getLessonStudentTelHref(lesson)"
-                        :href="getLessonStudentTelHref(lesson)!"
+                        v-if="getPlanningGridMeta(lesson)?.telHref"
+                        :href="getPlanningGridMeta(lesson)?.telHref!"
                         class="truncate text-blue-700 hover:underline"
                         @click.stop
-                      >{{ getLessonStudentPhonesDisplay(lesson) }}</a>
-                      <span v-else class="truncate">{{ getLessonStudentPhonesDisplay(lesson) }}</span>
+                      >{{ getPlanningGridMeta(lesson)?.phonesDisplay }}</a>
+                      <span v-else class="truncate">{{ getPlanningGridMeta(lesson)?.phonesDisplay }}</span>
                     </div>
                     
                     <!-- Coach -->
@@ -724,8 +724,8 @@
                         :key="'row-' + lesson.id"
                         class="border-t border-gray-200 transition-colors"
                         :class="[
-                          planningLessonRowHighlightClass(lesson) || (lesson.is_recurring_placeholder ? '' : 'bg-white hover:bg-blue-50/40'),
-                          planningLessonHasTeacherParallelConflict(lesson) ? 'border-l-4 border-l-red-600' : '',
+                          getPlanningGridMeta(lesson)?.rowHighlightClass || (lesson.is_recurring_placeholder ? '' : 'bg-white hover:bg-blue-50/40'),
+                          getPlanningGridMeta(lesson)?.hasTeacherConflict ? 'border-l-4 border-l-red-600' : '',
                           isSelectedDateClosure && lesson.status !== 'cancelled'
                             ? 'opacity-55 pointer-events-none'
                             : '',
@@ -738,7 +738,7 @@
                         <td class="px-3 py-2 align-top">
                           <div class="flex items-start gap-1.5">
                             <span
-                              v-if="planningLessonHasTeacherParallelConflict(lesson)"
+                              v-if="getPlanningGridMeta(lesson)?.hasTeacherConflict"
                               class="shrink-0 mt-0.5 text-red-600"
                               title="Sens interdit : ce coach a un autre cours en parallèle sur cette plage. Corrigez l’horaire ou changez d’enseignant."
                             >
@@ -748,7 +748,7 @@
                               </svg>
                             </span>
                             <span
-                              v-if="planningLessonOverlapsRecurringSeries(lesson)"
+                              v-if="getPlanningGridMeta(lesson)?.overlapsRecurring"
                               class="shrink-0 mt-0.5 text-violet-600"
                               title="Série récurrente (abonnement)">
                               <svg class="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.65" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -775,7 +775,7 @@
                                   {{ recurringPlaceholderSummaryLine(lesson) }}
                                 </p>
                                 <p
-                                  v-if="isPlaceholderFromCancelledLesson(lesson)"
+                                  v-if="getPlanningGridMeta(lesson)?.fromCancelled"
                                   class="mt-1 mb-0 text-xs font-medium text-amber-800 leading-snug">
                                   Séance annulée : emplacement utilisable pour un cours ponctuel.
                                 </p>
@@ -798,25 +798,25 @@
                             class="font-medium text-left text-blue-700 hover:underline"
                             @click.stop="openStudentInfoFromLesson(lesson)"
                           >
-                            {{ getLessonStudents(lesson) }}
+                            {{ getPlanningGridMeta(lesson)?.studentsLabel }}
                           </button>
-                          <span v-else class="font-medium">{{ getLessonStudents(lesson) }}</span>
+                          <span v-else class="font-medium">{{ getPlanningGridMeta(lesson)?.studentsLabel }}</span>
                           <span
-                            v-if="hasActiveSubscription(lesson)"
+                            v-if="getPlanningGridMeta(lesson)?.hasAbo"
                             class="ml-1 inline-flex items-center px-1 py-0.5 rounded text-[10px] font-medium bg-emerald-100 text-emerald-700"
                             title="Abonnement actif">Abo</span>
                           <div
-                            v-if="getLessonStudentPhonesDisplay(lesson)"
+                            v-if="getPlanningGridMeta(lesson)?.phonesDisplay"
                             class="mt-0.5 text-xs text-gray-600 flex items-center gap-1 min-w-0"
                           >
                             <span aria-hidden="true">📞</span>
                             <a
-                              v-if="getLessonStudentTelHref(lesson)"
-                              :href="getLessonStudentTelHref(lesson)!"
+                              v-if="getPlanningGridMeta(lesson)?.telHref"
+                              :href="getPlanningGridMeta(lesson)?.telHref!"
                               class="truncate text-blue-700 hover:underline"
                               @click.stop
-                            >{{ getLessonStudentPhonesDisplay(lesson) }}</a>
-                            <span v-else class="truncate">{{ getLessonStudentPhonesDisplay(lesson) }}</span>
+                            >{{ getPlanningGridMeta(lesson)?.phonesDisplay }}</a>
+                            <span v-else class="truncate">{{ getPlanningGridMeta(lesson)?.phonesDisplay }}</span>
                           </div>
                         </td>
                         <td class="px-3 py-2 align-top text-gray-600 truncate max-w-[10rem]">
@@ -1584,6 +1584,15 @@ function getApiClient() {
   return api
 }
 
+/** Logs planning uniquement en dev (évite le coût console en prod). */
+function planningDevLog(...args: unknown[]) {
+  if (import.meta.dev) {
+    // eslint-disable-next-line no-console
+    ;(console as Console).log(...args)
+  }
+}
+
+
 definePageMeta({
   middleware: ['auth']
 })
@@ -1835,52 +1844,57 @@ const pendingCertificateStudents = computed(() => {
   return list
 })
 
+function toLocalYmd(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function toLocalHm(d: Date): string {
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+/** Index O(1) par jour local — évite de rescanner toute la fenêtre 8 sem. à chaque filtre. */
+const lessonsByLocalDate = computed(() => {
+  const map = new Map<string, Lesson[]>()
+  for (const lesson of lessons.value) {
+    if (!lesson?.start_time) continue
+    const d = new Date(lesson.start_time as string)
+    if (Number.isNaN(d.getTime())) continue
+    const key = toLocalYmd(d)
+    const bucket = map.get(key)
+    if (bucket) {
+      bucket.push(lesson)
+    } else {
+      map.set(key, [lesson])
+    }
+  }
+  return map
+})
+
 // Cours filtrés par créneau sélectionné ET par date
 const filteredLessons = computed(() => {
   if (!selectedSlot.value) {
     // Sans créneau, ne rien rendre (évite une page gigantesque sur toute la plage chargée).
     return []
   }
-  
-  // Filtrer les cours qui correspondent au créneau sélectionné
-  return lessons.value.filter(lesson => {
+
+  const slot = selectedSlot.value
+  const slotStartTime = formatTime(slot.start_time)
+  const slotEndTime = formatTime(slot.end_time)
+
+  const candidates = selectedDate.value
+    ? (lessonsByLocalDate.value.get(toLocalYmd(selectedDate.value)) ?? [])
+    : lessons.value
+
+  return candidates.filter((lesson) => {
     const lessonDate = new Date(lesson.start_time)
-    // JavaScript getDay() retourne 0 (Dim) à 6 (Sam) - correspond à Laravel (0=Dim)
     const lessonDay = lessonDate.getDay()
-    
-    // 🔧 CORRECTION : Extraire l'heure locale au format "HH:mm"
-    // Utiliser les méthodes getHours() et getMinutes() pour éviter les problèmes de format
-    const lessonHours = String(lessonDate.getHours()).padStart(2, '0')
-    const lessonMinutes = String(lessonDate.getMinutes()).padStart(2, '0')
-    const lessonTime = `${lessonHours}:${lessonMinutes}` // Format: "09:00"
-    
-    // Normaliser les heures du créneau (au cas où elles sont en format "HH:mm:ss")
-    const slotStartTime = formatTime(selectedSlot.value!.start_time)
-    const slotEndTime = formatTime(selectedSlot.value!.end_time)
-    
-    const dayMatch = lessonDay === selectedSlot.value!.day_of_week
+    const lessonTime = toLocalHm(lessonDate)
+    const dayMatch = lessonDay === slot.day_of_week
     const timeMatch = lessonTime >= slotStartTime && lessonTime < slotEndTime
-    
-    // 📅 FILTRE PAR DATE : Si une date est sélectionnée, ne garder que les cours de cette date
-    // ⚠️ IMPORTANT : Comparer les dates en LOCAL, pas en UTC (problème de timezone)
-    let dateMatch = true
-    if (selectedDate.value) {
-      // Extraire la date locale (YYYY-MM-DD) de la date sélectionnée
-      const selectedYear = selectedDate.value.getFullYear()
-      const selectedMonth = String(selectedDate.value.getMonth() + 1).padStart(2, '0')
-      const selectedDay = String(selectedDate.value.getDate()).padStart(2, '0')
-      const selectedDateStr = `${selectedYear}-${selectedMonth}-${selectedDay}`
-      
-      // Extraire la date locale (YYYY-MM-DD) du cours
-      const lessonYear = lessonDate.getFullYear()
-      const lessonMonth = String(lessonDate.getMonth() + 1).padStart(2, '0')
-      const lessonDay = String(lessonDate.getDate()).padStart(2, '0')
-      const lessonDateStr = `${lessonYear}-${lessonMonth}-${lessonDay}`
-      
-      dateMatch = lessonDateStr === selectedDateStr
-    }
-    
-    return dayMatch && timeMatch && dateMatch
+    return dayMatch && timeMatch
   })
 })
 
@@ -1897,9 +1911,8 @@ const dayBroadcastRecipients = computed(() => {
     return { teachers: [], students: [] }
   }
 
-  const sel = selectedDate.value
-  const selStr = `${sel.getFullYear()}-${String(sel.getMonth() + 1).padStart(2, '0')}-${String(sel.getDate()).padStart(2, '0')}`
-  const selDow = sel.getDay()
+  const selStr = toLocalYmd(selectedDate.value)
+  const selDow = selectedDate.value.getDay()
 
   const addLessonParticipants = (lesson: Lesson) => {
     const teacherId = resolveLessonTeacherId(lesson)
@@ -1924,14 +1937,8 @@ const dayBroadcastRecipients = computed(() => {
     }
   }
 
-  for (const lesson of lessons.value) {
+  for (const lesson of lessonsByLocalDate.value.get(selStr) ?? []) {
     if ((lesson as any).is_recurring_placeholder || lesson.status === 'cancelled') continue
-    if (!lesson.start_time) continue
-
-    const d = new Date(lesson.start_time as string)
-    const lessonStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-    if (lessonStr !== selStr) continue
-
     addLessonParticipants(lesson)
   }
 
@@ -1943,7 +1950,7 @@ const dayBroadcastRecipients = computed(() => {
     if (Number(rs.day_of_week) !== selDow) continue
     if (!subscriptionRecurringSlotFiresOnDate(rs, selStr)) continue
 
-    const alreadyMaterialized = lessons.value.some(
+    const alreadyMaterialized = (lessonsByLocalDate.value.get(selStr) ?? []).some(
       (l) => !(l as any).is_recurring_placeholder
         && l.status !== 'cancelled'
         && lessonMaterializesRecurringOnDate(l, rs, selStr),
@@ -2177,7 +2184,8 @@ function recurringOccurrenceFreedByCancelledLesson(rs: { student_id?: number; te
   const sid = Number(rs.student_id)
   if (!sid) return false
 
-  return lessons.value.some((lesson) => {
+  const dayLessons = lessonsByLocalDate.value.get(dateStr) ?? []
+  return dayLessons.some((lesson) => {
     if (lesson.is_recurring_placeholder) return false
     if (lesson.status !== 'cancelled') return false
     const lid = Number(lesson.teacher_id ?? lesson.teacher?.id)
@@ -2186,11 +2194,6 @@ function recurringOccurrenceFreedByCancelledLesson(rs: { student_id?: number; te
 
     const ls = new Date(lesson.start_time)
     const le = new Date(lesson.end_time)
-    const ly = ls.getFullYear()
-    const lm = String(ls.getMonth() + 1).padStart(2, '0')
-    const ld = String(ls.getDate()).padStart(2, '0')
-    if (`${ly}-${lm}-${ld}` !== dateStr) return false
-
     return ls < rsEnd && le > rsStart
   })
 }
@@ -2220,11 +2223,20 @@ function recurringPlaceholderSummaryLine(lesson: Lesson): string {
  */
 const recurringPlanningPlaceholders = computed((): Lesson[] => {
   if (!selectedSlot.value || !selectedDate.value) return []
-  const d = selectedDate.value
-  const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  const dateStr = toLocalYmd(selectedDate.value)
   const slot = selectedSlot.value
   const slotStart = formatTime(slot.start_time)
   const slotEnd = formatTime(slot.end_time)
+  const dayFiltered = filteredLessons.value
+  // Index élève → cours du créneau (lookup O(1) vs find nested)
+  const byStudentId = new Map<number, Lesson[]>()
+  for (const l of dayFiltered) {
+    const sid = Number(l.student_id ?? (l as any).students?.[0]?.id)
+    if (!sid) continue
+    const bucket = byStudentId.get(sid)
+    if (bucket) bucket.push(l)
+    else byStudentId.set(sid, [l])
+  }
   const out: Lesson[] = []
   for (const rs of clubRecurringSlots.value) {
     if (rs.status !== 'active') continue
@@ -2234,9 +2246,8 @@ const recurringPlanningPlaceholders = computed((): Lesson[] => {
     if (!subscriptionRecurringSlotFiresOnDate(rs, dateStr)) continue
     const rsStart = formatTime(rs.start_time)
     if (!(rsStart >= slotStart && rsStart < slotEnd)) continue
-    const covering = filteredLessons.value.find((l) =>
-      lessonMaterializesRecurringOnDate(l, rs, dateStr)
-    )
+    const candidates = byStudentId.get(Number(rs.student_id)) ?? []
+    const covering = candidates.find((l) => lessonMaterializesRecurringOnDate(l, rs, dateStr))
     if (covering) continue
     // Cours annulé ce jour : plage libérée, série inchangée pour les occurrences futures
     if (recurringOccurrenceFreedByCancelledLesson(rs, dateStr)) continue
@@ -2367,56 +2378,30 @@ function planningLessonRowHighlightClass(lesson: Lesson): string {
 // Types de cours filtrés - Utilise les courseTypes du créneau sélectionné
 // au lieu de filtrer la liste globale (relation directe créneau → types)
 const filteredCourseTypes = computed(() => {
-  console.log('🔄 [filteredCourseTypes] Computed appelé', {
-    hasSlot: !!selectedSlotForLesson.value,
-    slotId: selectedSlotForLesson.value?.id,
-    slotDisciplineId: selectedSlotForLesson.value?.discipline_id,
-    slotHasCourseTypes: !!selectedSlotForLesson.value?.course_types,
-    modalOpen: showCreateLessonModal.value,
-    clubDisciplinesCount: clubDisciplines.value.length,
-    clubDisciplineIds: clubDisciplines.value.map(d => d.id)
-  })
-  
   // Si la modale n'est pas ouverte, retourner un tableau vide
   if (!showCreateLessonModal.value) {
-    console.log('⚠️ [filteredCourseTypes] Modale fermée → tableau vide')
     return []
   }
   
   // Si pas de créneau sélectionné, retourner tableau vide
   if (!selectedSlotForLesson.value) {
-    console.log('⚠️ [filteredCourseTypes] Pas de créneau → tableau vide')
     return []
   }
   
   // ✅ Les courseTypes sont déjà filtrés par le backend selon les disciplines du club
-  // Le backend (ClubOpenSlotController::index) filtre pour ne garder que :
-  // 1. Les types génériques (sans discipline_id)
-  // 2. Les types dont la discipline_id est dans les disciplines activées du club
   const slotCourseTypes = selectedSlotForLesson.value.course_types || []
   
-  console.log('🎯 [filteredCourseTypes] Types de cours du créneau (déjà filtrés par le backend)', {
-    slotId: selectedSlotForLesson.value.id,
-    slotDisciplineId: selectedSlotForLesson.value.discipline_id,
-    slotDisciplineName: selectedSlotForLesson.value.discipline?.name,
-    courseTypesCount: slotCourseTypes.length,
-    courseTypes: slotCourseTypes.map(ct => ({ 
-      id: ct.id, 
-      name: ct.name,
-      discipline_id: ct.discipline_id,
-      duration: ct.duration || ct.duration_minutes,
-      price: ct.price
-    }))
-  })
-  
-  // ⚠️ Si aucun type de cours n'est disponible, afficher un avertissement
-  if (slotCourseTypes.length === 0) {
-    console.warn('⚠️ [filteredCourseTypes] Aucun type de cours disponible !', {
+  if (import.meta.dev) {
+    planningDevLog('🎯 [filteredCourseTypes] Types de cours du créneau', {
       slotId: selectedSlotForLesson.value.id,
-      slotDisciplineId: selectedSlotForLesson.value.discipline_id,
-      clubDisciplines: clubDisciplines.value.map(d => ({ id: d.id, name: d.name })),
-      message: 'Vérifiez que des types de cours sont associés à ce créneau et correspondent aux disciplines du club'
+      courseTypesCount: slotCourseTypes.length,
     })
+    if (slotCourseTypes.length === 0) {
+      console.warn('⚠️ [filteredCourseTypes] Aucun type de cours disponible !', {
+        slotId: selectedSlotForLesson.value.id,
+        slotDisciplineId: selectedSlotForLesson.value.discipline_id,
+      })
+    }
   }
   
   return slotCourseTypes
@@ -2434,7 +2419,7 @@ watch(() => slotForm.value.discipline_id, (newDisciplineId) => {
       slotForm.value.price = selectedDiscipline.settings.price || 0
       slotForm.value.max_capacity = selectedDiscipline.settings.max_participants || 1
       
-      console.log('✨ Valeurs initialisées depuis la discipline:', {
+      planningDevLog('✨ Valeurs initialisées depuis la discipline:', {
         duration: slotForm.value.duration,
         price: slotForm.value.price,
         max_capacity: slotForm.value.max_capacity
@@ -2457,7 +2442,7 @@ watch(() => lessonForm.value.course_type_id, (newCourseTypeId) => {
       // Utiliser duration_minutes en priorité, puis duration
       lessonForm.value.duration = courseType.duration_minutes || courseType.duration || 60
       lessonForm.value.price = courseType.price || 0
-      console.log('✨ Durée et prix initialisés depuis type de cours:', {
+      planningDevLog('✨ Durée et prix initialisés depuis type de cours:', {
         name: courseType.name,
         duration: lessonForm.value.duration,
         price: lessonForm.value.price,
@@ -2473,7 +2458,7 @@ watch(() => selectedSlotForLesson.value, (newSlot, oldSlot) => {
   if (newSlot && oldSlot && newSlot.discipline_id !== oldSlot.discipline_id) {
     // Réinitialiser le type de cours car les options disponibles ont changé
     lessonForm.value.course_type_id = null
-    console.log('🔄 Type de cours réinitialisé suite au changement de créneau')
+    planningDevLog('🔄 Type de cours réinitialisé suite au changement de créneau')
   }
 })
 
@@ -2496,41 +2481,37 @@ watch(() => [lessonForm.value.date, lessonForm.value.time], ([date, time]) => {
 // Fonctions
 async function loadClubDisciplines() {
   try {
-    loading.value = true
     error.value = null
     
     const $api = getApiClient()
     const config = useRuntimeConfig()
     
-    console.log('🔍 Début du chargement des disciplines...')
+    if (import.meta.dev) {
+      planningDevLog('🔍 Début du chargement des disciplines...')
+    }
     
-    // 1. Récupérer le profil du club avec les disciplines configurées
-    const profileResponse = await $api.get('/club/profile')
+    // Profil club + référentiel disciplines en parallèle
+    const [profileResponse, disciplinesResponse] = await Promise.all([
+      $api.get('/club/profile'),
+      $fetch(`${config.public.apiBase}/disciplines`) as Promise<{ data?: any[] }>,
+    ])
     
-    console.log('📥 Réponse profil brute:', profileResponse.data)
+    if (import.meta.dev) {
+      planningDevLog('📥 Réponse profil brute:', profileResponse.data)
+    }
     
     if (!profileResponse.data.success || !profileResponse.data.data) {
       throw new Error('Impossible de récupérer le profil du club')
     }
     
     const clubData = profileResponse.data.data
-    
-    console.log('🏢 Données du club:', {
-      id: clubData.id,
-      name: clubData.name,
-      disciplines_raw: clubData.disciplines,
-      disciplines_type: typeof clubData.disciplines,
-      discipline_settings_raw: clubData.discipline_settings,
-      discipline_settings_type: typeof clubData.discipline_settings
-    })
-    
-    // 2. Récupérer la liste complète des disciplines pour avoir les noms
-    const disciplinesResponse = await $fetch(`${config.public.apiBase}/disciplines`)
     const allDisciplines = disciplinesResponse.data || []
     
-    console.log('📚 Disciplines disponibles:', allDisciplines.map((d: any) => ({ id: d.id, name: d.name })))
+    if (import.meta.dev) {
+      planningDevLog('📚 Disciplines disponibles:', allDisciplines.map((d: any) => ({ id: d.id, name: d.name })))
+    }
     
-    // 3. Parser les données du club
+    // Parser les données du club
     let clubDisciplineIds = []
     
     if (clubData.disciplines) {
@@ -2561,24 +2542,17 @@ async function loadClubDisciplines() {
       }
     }
     
-    console.log('✅ Données parsées:', {
-      clubDisciplineIds,
-      disciplineSettings
-    })
-    
-    // 4. Construire la liste des disciplines avec leurs settings
+    // Construire la liste des disciplines avec leurs settings
     clubDisciplines.value = clubDisciplineIds
       .map((disciplineId: number) => {
-        console.log(`🔍 Recherche discipline ID ${disciplineId}...`)
         const discipline = allDisciplines.find((d: Discipline) => d.id === disciplineId)
         
         if (!discipline) {
-          console.warn(`❌ Discipline ${disciplineId} non trouvée dans le référentiel`)
-          console.log('   IDs disponibles:', allDisciplines.map((d: any) => d.id))
+          if (import.meta.dev) {
+            console.warn(`❌ Discipline ${disciplineId} non trouvée dans le référentiel`)
+          }
           return null
         }
-        
-        console.log(`✅ Discipline ${disciplineId} trouvée:`, discipline.name)
         
         const settings = disciplineSettings[disciplineId] || {
           duration: 45,
@@ -2588,8 +2562,6 @@ async function loadClubDisciplines() {
   notes: ''
         }
         
-        console.log(`   Settings pour ${discipline.name}:`, settings)
-        
       return {
           ...discipline,
           settings
@@ -2597,15 +2569,14 @@ async function loadClubDisciplines() {
       })
       .filter((d): d is ClubDiscipline => d !== null)
     
-    console.log('🎯 RÉSULTAT FINAL:', clubDisciplines.value)
-    console.log('📊 Nombre de disciplines actives:', activeDisciplines.value.length)
+    if (import.meta.dev) {
+      planningDevLog('🎯 Disciplines club:', clubDisciplines.value.length)
+    }
   } catch (err: any) {
     console.error('❌ ERREUR:', err)
     const errorMessage = err.message || 'Erreur lors du chargement des disciplines'
     error.value = errorMessage
     showError(errorMessage, 'Erreur de chargement')
-  } finally {
-    loading.value = false
   }
 }
 
@@ -2673,11 +2644,11 @@ function findNearestSlot(): OpenSlot | null {
 async function loadOpenSlots() {
   try {
     const $api = getApiClient()
-    console.log('🔄 [Planning] Chargement des créneaux horaires...')
+    planningDevLog('🔄 [Planning] Chargement des créneaux horaires...')
     
     const response = await $api.get('/club/open-slots')
     
-    console.log('📥 [Planning] Réponse API créneaux:', {
+    planningDevLog('📥 [Planning] Réponse API créneaux:', {
       success: response.data.success,
       data_type: typeof response.data.data,
       data_is_array: Array.isArray(response.data.data),
@@ -2687,7 +2658,7 @@ async function loadOpenSlots() {
     
     if (response.data.success) {
       openSlots.value = Array.isArray(response.data.data) ? response.data.data : []
-      console.log('✅ Créneaux chargés:', openSlots.value.length, 'créneaux')
+      planningDevLog('✅ Créneaux chargés:', openSlots.value.length, 'créneaux')
       
       if (openSlots.value.length === 0) {
         console.warn('⚠️ Aucun créneau trouvé pour ce club')
@@ -2697,7 +2668,7 @@ async function loadOpenSlots() {
           ? openSlots.value.find((s: any) => s.id === Number(slotIdFromQuery))
           : findNearestSlot()
         if (slotToSelect) {
-          console.log('🎯 Créneau sélectionné:', slotIdFromQuery ? 'depuis URL' : 'plus proche', {
+          planningDevLog('🎯 Créneau sélectionné:', slotIdFromQuery ? 'depuis URL' : 'plus proche', {
             id: slotToSelect.id,
             day: getDayName(slotToSelect.day_of_week),
             time: formatTime(slotToSelect.start_time),
@@ -2705,13 +2676,13 @@ async function loadOpenSlots() {
           })
           handleSlotSelection(slotToSelect)
         } else {
-          console.log('⚠️ Aucun créneau actif trouvé pour présélectionner')
+          planningDevLog('⚠️ Aucun créneau actif trouvé pour présélectionner')
         }
       }
       
       // 🔍 DEBUG: Vérifier les course_types dans chaque slot
       openSlots.value.forEach((slot, index) => {
-        console.log(`🔍 [Slot ${index + 1}] ID: ${slot.id}`, {
+        planningDevLog(`🔍 [Slot ${index + 1}] ID: ${slot.id}`, {
           club_id: slot.club_id,
           day_of_week: slot.day_of_week,
           start_time: slot.start_time,
@@ -2766,6 +2737,7 @@ async function loadLessons(customStartDate?: Date, customEndDate?: Date) {
     
     const response = await $api.get('/lessons', {
       params: {
+        context: 'planning',
         date_from: startDate.toISOString().split('T')[0],
         date_to: endDate.toISOString().split('T')[0]
         // Pas de limite : on filtre par plage (cap API date range).
@@ -2780,12 +2752,12 @@ async function loadLessons(customStartDate?: Date, customEndDate?: Date) {
         const lessonsToAdd = newLessons.filter((l: any) => !existingLessonIds.has(l.id))
         lessons.value = [...lessons.value, ...lessonsToAdd]
         if (import.meta.dev) {
-          console.log('✅ Cours fusionnés:', { nouveaux: lessonsToAdd.length, total: lessons.value.length })
+          planningDevLog('✅ Cours fusionnés:', { nouveaux: lessonsToAdd.length, total: lessons.value.length })
         }
       } else {
         lessons.value = newLessons
         if (import.meta.dev) {
-          console.log('✅ Cours chargés:', { total: lessons.value.length })
+          planningDevLog('✅ Cours chargés:', { total: lessons.value.length })
         }
       }
       
@@ -2809,7 +2781,7 @@ async function loadLessons(customStartDate?: Date, customEndDate?: Date) {
       }
 
       if (import.meta.dev) {
-        console.log('📋 Plage cours chargée:', {
+        planningDevLog('📋 Plage cours chargée:', {
           total: lessons.value.length,
           start: loadedLessonsRange.value.start?.toISOString().split('T')[0],
           end: loadedLessonsRange.value.end?.toISOString().split('T')[0],
@@ -3106,9 +3078,9 @@ async function loadPendingCertificates() {
     const list = response.data?.data
     pendingCertificateLessons.value = Array.isArray(list) ? list : []
     if (import.meta.dev) {
-      console.log('[Planning] CM à valider:', pendingCertificateLessons.value.length, response.data)
+      planningDevLog('[Planning] CM à valider:', pendingCertificateLessons.value.length, response.data)
       if (response.data?._debug) {
-        console.log('[Planning] pending-certificates _debug:', response.data._debug)
+        planningDevLog('[Planning] pending-certificates _debug:', response.data._debug)
       }
     }
   } catch (err: any) {
@@ -3119,16 +3091,43 @@ async function loadPendingCertificates() {
   }
 }
 
+const modalListsLoaded = ref(false)
+let modalListsPromise: Promise<void> | null = null
+
+/** Teachers / students : lazy au premier open modale. courseTypes chargé au mount (filtre DisciplinesList). */
+async function ensureModalListsLoaded() {
+  if (modalListsLoaded.value) return
+  if (modalListsPromise) {
+    await modalListsPromise
+    return
+  }
+  modalListsPromise = (async () => {
+    const tasks: Promise<void>[] = [loadTeachers(), loadStudents()]
+    if (courseTypes.value.length === 0) {
+      tasks.push(loadCourseTypes())
+    }
+    await Promise.all(tasks)
+    modalListsLoaded.value = true
+  })().finally(() => {
+    modalListsPromise = null
+  })
+  await modalListsPromise
+}
+
 // Charger les enseignants du club
 async function loadTeachers() {
   try {
     const { $api } = useNuxtApp()
     const response = await $api.get('/club/teachers')
-    console.log('🔍 [Planning] Réponse enseignants:', response.data)
+    if (import.meta.dev) {
+      planningDevLog('🔍 [Planning] Réponse enseignants:', response.data)
+    }
     if (response.data.success) {
       // La clé est 'teachers' et non 'data' (voir ClubController::getTeachers)
       teachers.value = response.data.teachers || response.data.data || []
-      console.log('✅ Enseignants chargés:', teachers.value.length)
+      if (import.meta.dev) {
+        planningDevLog('✅ Enseignants chargés:', teachers.value.length)
+      }
     }
   } catch (err: any) {
     console.error('Erreur chargement enseignants:', err)
@@ -3157,10 +3156,14 @@ async function loadStudents() {
         status: 'active' // Seulement les élèves actifs
       }
     })
-    console.log('🔍 [Planning] Réponse élèves:', response.data)
+    if (import.meta.dev) {
+      planningDevLog('🔍 [Planning] Réponse élèves:', response.data)
+    }
     if (response.data.success) {
       students.value = response.data.data || []
-      console.log('✅ Élèves chargés:', students.value.length)
+      if (import.meta.dev) {
+        planningDevLog('✅ Élèves chargés:', students.value.length)
+      }
       
       // Si on a reçu exactement le nombre de per_page, il pourrait y avoir plus d'élèves
       // Dans ce cas, charger les pages suivantes
@@ -3179,11 +3182,15 @@ async function loadStudents() {
               allStudents.push(...nextPageResponse.data.data)
             }
           } catch (pageErr) {
-            console.warn(`Erreur chargement page ${page} des élèves:`, pageErr)
+            if (import.meta.dev) {
+              console.warn(`Erreur chargement page ${page} des élèves:`, pageErr)
+            }
           }
         }
         students.value = allStudents
-        console.log('✅ Tous les élèves chargés:', students.value.length)
+        if (import.meta.dev) {
+          planningDevLog('✅ Tous les élèves chargés:', students.value.length)
+        }
       }
     }
   } catch (err: any) {
@@ -3207,14 +3214,16 @@ async function loadCourseTypes() {
     
     if (response.data.success) {
       courseTypes.value = response.data.data
-      console.log('✅ Types de cours chargés:', courseTypes.value.length)
-      console.log('📋 Détail des types de cours:', courseTypes.value.map(ct => ({
-        id: ct.id,
-        name: ct.name,
-        discipline_id: ct.discipline_id,
-        duration_minutes: ct.duration_minutes,
-        price: ct.price
-      })))
+      if (import.meta.dev) {
+        planningDevLog('✅ Types de cours chargés:', courseTypes.value.length)
+        planningDevLog('📋 Détail des types de cours:', courseTypes.value.map(ct => ({
+          id: ct.id,
+          name: ct.name,
+          discipline_id: ct.discipline_id,
+          duration_minutes: ct.duration_minutes,
+          price: ct.price
+        })))
+      }
     }
   } catch (err: any) {
     console.error('Erreur chargement types de cours:', err)
@@ -3239,7 +3248,7 @@ function updateAvailableDays() {
     }
   })
   availableDaysOfWeek.value = Array.from(days).sort()
-  console.log('📅 Jours disponibles:', availableDaysOfWeek.value)
+  planningDevLog('📅 Jours disponibles:', availableDaysOfWeek.value)
 }
 
 // Vérifier si une date correspond à un jour disponible
@@ -3256,13 +3265,13 @@ async function openSlotModal(slot?: OpenSlot) {
     // Recharger le slot depuis la DB pour avoir le statut actuel
     try {
       const { $api } = useNuxtApp()
-      console.log('🔄 [openSlotModal] Rechargement du créneau depuis la DB:', slot.id)
+      planningDevLog('🔄 [openSlotModal] Rechargement du créneau depuis la DB:', slot.id)
       
       const response = await $api.get(`/club/open-slots/${slot.id}`)
       
       if (response.data.success && response.data.data) {
         const freshSlot = response.data.data
-        console.log('✅ [openSlotModal] Créneau rechargé depuis la DB:', {
+        planningDevLog('✅ [openSlotModal] Créneau rechargé depuis la DB:', {
           id: freshSlot.id,
           is_active: freshSlot.is_active
         })
@@ -3357,7 +3366,7 @@ async function saveSlot() {
       is_active: isActive
     }
     
-    console.log('💾 [saveSlot] Envoi du payload:', {
+    planningDevLog('💾 [saveSlot] Envoi du payload:', {
       ...payload,
       is_active_type: typeof payload.is_active,
       is_active_value: payload.is_active
@@ -3366,11 +3375,11 @@ async function saveSlot() {
     if (editingSlot.value) {
       // Mise à jour
       const response = await $api.put(`/club/open-slots/${editingSlot.value.id}`, payload)
-      console.log('✅ Créneau mis à jour:', response.data)
+      planningDevLog('✅ Créneau mis à jour:', response.data)
     } else {
       // Création
       const response = await $api.post('/club/open-slots', payload)
-      console.log('✅ Créneau créé:', response.data)
+      planningDevLog('✅ Créneau créé:', response.data)
     }
     
     // Recharger la liste
@@ -3419,7 +3428,7 @@ async function deleteSlot(id: number) {
   try {
     const { $api } = useNuxtApp()
     await $api.delete(`/club/open-slots/${id}`)
-    console.log('✅ Créneau supprimé')
+    planningDevLog('✅ Créneau supprimé')
     
     // Recharger la liste
     await loadOpenSlots()
@@ -3439,7 +3448,10 @@ async function deleteSlot(id: number) {
 }
 
 async function openCreateLessonModal(slot?: OpenSlot, customTime?: string, explicitDate?: string) {
-  console.log('📝 [openCreateLessonModal] DÉBUT - Avant mise à jour selectedSlotForLesson', {
+  await ensureModalListsLoaded()
+
+  if (import.meta.dev) {
+  planningDevLog('📝 [openCreateLessonModal] DÉBUT - Avant mise à jour selectedSlotForLesson', {
     hasSlot: !!slot,
     slotId: slot?.id,
     slotDisciplineId: slot?.discipline_id,
@@ -3450,6 +3462,7 @@ async function openCreateLessonModal(slot?: OpenSlot, customTime?: string, expli
     totalCourseTypes: courseTypes.value.length,
     currentSelectedSlot: selectedSlotForLesson.value?.id
   })
+  }
 
   selectedSlotForLesson.value = slot || null
 
@@ -3460,15 +3473,15 @@ async function openCreateLessonModal(slot?: OpenSlot, customTime?: string, expli
       dateToUse = new Date(explicitDate + 'T00:00:00')
       selectedDate.value = dateToUse
       selectedDateInput.value = explicitDate
-      console.log('📅 [openCreateLessonModal] Date explicite (ex. depuis Plages disponibles):', explicitDate)
+      planningDevLog('📅 [openCreateLessonModal] Date explicite (ex. depuis Plages disponibles):', explicitDate)
     } else if (selectedDate.value && selectedDate.value.getDay() === slot.day_of_week) {
       dateToUse = new Date(selectedDate.value)
-      console.log('📅 [openCreateLessonModal] Utilisation de la date sélectionnée:', formatDateForInput(dateToUse))
+      planningDevLog('📅 [openCreateLessonModal] Utilisation de la date sélectionnée:', formatDateForInput(dateToUse))
     } else {
       dateToUse = getDefaultDateForSlotDay(slot.day_of_week)
       selectedDate.value = dateToUse
       selectedDateInput.value = formatDateForInput(dateToUse)
-      console.log('📅 [openCreateLessonModal] Date par défaut du créneau:', formatDateForInput(dateToUse))
+      planningDevLog('📅 [openCreateLessonModal] Date par défaut du créneau:', formatDateForInput(dateToUse))
     }
 
     const dateStr = formatDateForInput(dateToUse)
@@ -3492,7 +3505,7 @@ async function openCreateLessonModal(slot?: OpenSlot, customTime?: string, expli
         initialPrice = matchingCourseType.price || initialPrice
       }
 
-      console.log('🔍 Recherche type de cours pour discipline', slot.discipline_id, ':', {
+      planningDevLog('🔍 Recherche type de cours pour discipline', slot.discipline_id, ':', {
         found: !!matchingCourseType,
         selectedId: courseTypeId,
         selectedName: matchingCourseType?.name,
@@ -3507,7 +3520,7 @@ async function openCreateLessonModal(slot?: OpenSlot, customTime?: string, expli
           initialDuration = matchingCourseType.duration_minutes || matchingCourseType.duration || initialDuration
           initialPrice = matchingCourseType.price || initialPrice
         }
-        console.log('⚠️ [openCreateLessonModal] Aucun type de cours dans le créneau, recherche dans tous les types:', {
+        planningDevLog('⚠️ [openCreateLessonModal] Aucun type de cours dans le créneau, recherche dans tous les types:', {
           found: !!matchingCourseType,
           selectedId: courseTypeId
         })
@@ -3553,7 +3566,7 @@ async function openCreateLessonModal(slot?: OpenSlot, customTime?: string, expli
 }
 
 function closeCreateLessonModal() {
-  console.log('🚪 [closeCreateLessonModal] Fermeture modale')
+  planningDevLog('🚪 [closeCreateLessonModal] Fermeture modale')
   showCreateLessonModal.value = false
   createLessonRequestedTime.value = null
   
@@ -3584,7 +3597,7 @@ function closeCreateLessonModal() {
   // que le computed retourne tous les types pendant la fermeture
   setTimeout(() => {
     selectedSlotForLesson.value = null
-    console.log('🧹 [closeCreateLessonModal] selectedSlotForLesson réinitialisé après délai')
+    planningDevLog('🧹 [closeCreateLessonModal] selectedSlotForLesson réinitialisé après délai')
   }, 100)
 }
 
@@ -3594,9 +3607,11 @@ async function openEditLessonModal(lesson: Lesson) {
     navigateTo('/club/recurring-slots')
     return
   }
+  await ensureModalListsLoaded()
   editingLesson.value = lesson
   
-  console.log('📝 [openEditLessonModal] Chargement des données du cours:', {
+  if (import.meta.dev) {
+  planningDevLog('📝 [openEditLessonModal] Chargement des données du cours:', {
     id: lesson.id,
     start_time: lesson.start_time,
     course_type: lesson.course_type,
@@ -3604,7 +3619,7 @@ async function openEditLessonModal(lesson: Lesson) {
     subscription_instances: (lesson as any).subscription_instances,
     teacher: lesson.teacher
   })
-  
+  }
   // Extraire la date et l'heure depuis start_time
   if (lesson.start_time) {
     const dateTime = new Date(lesson.start_time)
@@ -3621,7 +3636,7 @@ async function openEditLessonModal(lesson: Lesson) {
       time: lessonForm.value.time
     }
     
-    console.log('📅 [openEditLessonModal] Date et heure extraites:', {
+    planningDevLog('📅 [openEditLessonModal] Date et heure extraites:', {
       date: lessonForm.value.date,
       time: lessonForm.value.time,
       start_time: lesson.start_time,
@@ -3641,7 +3656,7 @@ async function openEditLessonModal(lesson: Lesson) {
     const matchingSlot = findSlotContainingTime(slotsSameDay, lessonStartStr, duration) ?? slotsSameDay[0] ?? null
     if (matchingSlot) {
       selectedSlotForLesson.value = matchingSlot
-      console.log('🎯 [openEditLessonModal] Créneau trouvé (contenant l\'heure du cours):', {
+      planningDevLog('🎯 [openEditLessonModal] Créneau trouvé (contenant l\'heure du cours):', {
         day_of_week: dayOfWeek,
         slot_id: matchingSlot.id,
         slot_start: matchingSlot.start_time,
@@ -3675,7 +3690,7 @@ async function openEditLessonModal(lesson: Lesson) {
   
   // DCL/NDCL : est_legacy = false pour DCL, true pour NDCL
   lessonForm.value.est_legacy = (lesson as any).est_legacy !== undefined ? Boolean((lesson as any).est_legacy) : false
-  console.log('🏷️ [openEditLessonModal] Classification chargée:', {
+  planningDevLog('🏷️ [openEditLessonModal] Classification chargée:', {
     est_legacy: lessonForm.value.est_legacy,
     label: lessonForm.value.est_legacy ? 'NDCL' : 'DCL',
     raw_value: (lesson as any).est_legacy
@@ -3689,7 +3704,7 @@ async function openEditLessonModal(lesson: Lesson) {
     const hasSubscriptionInstances = (lesson as any).subscription_instances && Array.isArray((lesson as any).subscription_instances) && (lesson as any).subscription_instances.length > 0
     lessonForm.value.deduct_from_subscription = hasSubscriptionInstances
   }
-  console.log('💳 [openEditLessonModal] Déduction d\'abonnement chargée:', {
+  planningDevLog('💳 [openEditLessonModal] Déduction d\'abonnement chargée:', {
     deduct_from_subscription: lessonForm.value.deduct_from_subscription,
     raw_value: (lesson as any).deduct_from_subscription,
     has_subscription_instances: (lesson as any).subscription_instances?.length > 0
@@ -3734,7 +3749,7 @@ function closeEditLessonModal() {
 
 // Gestion de la sélection de créneau
 function handleSlotSelection(slot: OpenSlot) {
-  console.log('🎯 [handleSlotSelection] Créneau sélectionné:', slot.id)
+  planningDevLog('🎯 [handleSlotSelection] Créneau sélectionné:', slot.id)
   selectedSlot.value = slot
   
   // 📅 Initialiser la date à la prochaine occurrence du créneau
@@ -3756,7 +3771,7 @@ async function createLesson() {
     const { $api } = useNuxtApp()
     
     // 🔍 DEBUG : Afficher l'état du formulaire
-    console.log('🔍 [createLesson] État du formulaire:', {
+    planningDevLog('🔍 [createLesson] État du formulaire:', {
       teacher_id: lessonForm.value.teacher_id,
       teacher_id_type: typeof lessonForm.value.teacher_id,
       student_id: lessonForm.value.student_id,
@@ -3852,12 +3867,12 @@ async function createLesson() {
         : 0))
     }
     
-    console.log('📤 Création du cours avec payload:', payload)
+    planningDevLog('📤 Création du cours avec payload:', payload)
     
     const response = await $api.post('/lessons', payload)
     
     if (response.data.success) {
-      console.log('✅ Cours créé:', response.data.data)
+      planningDevLog('✅ Cours créé:', response.data.data)
       success('Cours créé avec succès', 'Succès')
       
       // Recharger les cours et les récurrences (affichage séries / placeholders)
@@ -3868,7 +3883,7 @@ async function createLesson() {
       if (selectedDate.value && selectedSlot.value && 
           selectedDate.value.getDay() === selectedSlot.value.day_of_week) {
         // La date est déjà correcte, pas besoin de la modifier
-        console.log('📅 [createLesson] Conservation de la date sélectionnée:', selectedDate.value.toISOString().split('T')[0])
+        planningDevLog('📅 [createLesson] Conservation de la date sélectionnée:', selectedDate.value.toISOString().split('T')[0])
       } else if (selectedSlot.value && lessonForm.value.date) {
         // Si une date a été sélectionnée dans le formulaire et qu'un créneau est sélectionné,
         // mettre à jour selectedDate pour rester sur cette date
@@ -3876,7 +3891,7 @@ async function createLesson() {
         if (createdDate.getDay() === selectedSlot.value.day_of_week) {
           selectedDate.value = createdDate
           selectedDateInput.value = formatDateForInput(createdDate)
-          console.log('📅 [createLesson] Mise à jour de selectedDate avec la date du cours créé:', selectedDate.value.toISOString().split('T')[0])
+          planningDevLog('📅 [createLesson] Mise à jour de selectedDate avec la date du cours créé:', selectedDate.value.toISOString().split('T')[0])
         }
       }
       
@@ -3994,14 +4009,14 @@ async function loadFutureLessonsCount() {
                                 lesson.student?.subscription_instances ||
                                 (lesson.students && lesson.students.length > 0 ? lesson.students[0].subscription_instances : null)
   
-  console.log('🔍 [loadFutureLessonsCount] Début du chargement', {
+  planningDevLog('🔍 [loadFutureLessonsCount] Début du chargement', {
     hasLesson: !!editingLesson.value,
     hasSubscriptionInstances: !!subscriptionInstances,
     subscriptionInstancesCount: subscriptionInstances?.length || 0
   })
   
   if (!subscriptionInstances || subscriptionInstances.length === 0) {
-    console.log('⚠️ [loadFutureLessonsCount] Aucune instance d\'abonnement trouvée')
+    planningDevLog('⚠️ [loadFutureLessonsCount] Aucune instance d\'abonnement trouvée')
     futureLessonsCount.value = 0
     return
   }
@@ -4011,7 +4026,7 @@ async function loadFutureLessonsCount() {
     const subscriptionInstanceId = subscriptionInstances[0].id
     const currentLessonDate = new Date(editingLesson.value.start_time)
     
-    console.log('📅 [loadFutureLessonsCount] Paramètres', {
+    planningDevLog('📅 [loadFutureLessonsCount] Paramètres', {
       subscriptionInstanceId,
       currentLessonDate: currentLessonDate.toISOString().split('T')[0],
       startTime: editingLesson.value.start_time
@@ -4024,7 +4039,7 @@ async function loadFutureLessonsCount() {
       }
     })
     
-    console.log('✅ [loadFutureLessonsCount] Réponse API', {
+    planningDevLog('✅ [loadFutureLessonsCount] Réponse API', {
       success: response.data.success,
       count: response.data.data?.count,
       data: response.data.data
@@ -4032,7 +4047,7 @@ async function loadFutureLessonsCount() {
     
     if (response.data.success) {
       futureLessonsCount.value = response.data.data?.count || 0
-      console.log('✅ [loadFutureLessonsCount] Nombre de cours futurs:', futureLessonsCount.value)
+      planningDevLog('✅ [loadFutureLessonsCount] Nombre de cours futurs:', futureLessonsCount.value)
     } else {
       console.warn('⚠️ [loadFutureLessonsCount] Réponse non réussie:', response.data)
       futureLessonsCount.value = 0
@@ -4088,7 +4103,7 @@ async function performUpdate(updatePayload: any, scope: 'single' | 'all_future')
       payloadWithScope.recurring_interval = lessonForm.value.recurring_interval
     }
     
-    console.log('📤 Mise à jour du cours avec payload:', payloadWithScope)
+    planningDevLog('📤 Mise à jour du cours avec payload:', payloadWithScope)
     
     // Mettre à jour le cours
     const response = await $api.put(`/lessons/${editingLesson.value.id}`, payloadWithScope)
@@ -4360,7 +4375,7 @@ async function openCreateLessonModalForTimeSlot(timeSlot: string) {
   // Utiliser le créneau sélectionné et la date sélectionnée avec l'heure de la plage horaire
   await openCreateLessonModal(selectedSlot.value, timeSlot)
   
-  console.log('📅 [openCreateLessonModalForTimeSlot] Modale ouverte avec:', {
+  planningDevLog('📅 [openCreateLessonModalForTimeSlot] Modale ouverte avec:', {
     date: formatDateForInput(selectedDate.value),
     time: timeSlot,
     slot: selectedSlot.value.id,
@@ -4765,7 +4780,7 @@ async function checkAndReloadLessonsIfNeeded(targetDate: Date) {
   if (!loadedStart || !loadedEnd) {
     // Si aucune plage n'est chargée, charger autour de la date cible
     if (import.meta.dev) {
-      console.log('🔄 Aucune plage cours, chargement chunk autour de:', targetDate.toISOString().split('T')[0])
+      planningDevLog('🔄 Aucune plage cours, chargement chunk autour de:', targetDate.toISOString().split('T')[0])
     }
     const { start: startDate, end: endDate } = getClubPlanningLoadRangeAround(targetDate)
     await loadLessons(startDate, endDate)
@@ -4780,7 +4795,7 @@ async function checkAndReloadLessonsIfNeeded(targetDate: Date) {
   
   if (needsReload) {
     if (import.meta.dev) {
-      console.log('🔄 Extension plage cours pour:', targetDate.toISOString().split('T')[0])
+      planningDevLog('🔄 Extension plage cours pour:', targetDate.toISOString().split('T')[0])
     }
     
     // Calculer la nouvelle plage à charger
@@ -5004,8 +5019,13 @@ function getLessonStudentTelHref(lesson: Lesson | null): string | null {
 function hasActiveSubscription(lesson: Lesson | null): boolean {
   if (!lesson) return false
   if (lesson.is_recurring_placeholder) return true
+
+  // Lien abo sur le cours (payload planning slim : subscription_instances: [{id}])
+  if ((lesson as any).subscription_instances?.length > 0) {
+    return true
+  }
   
-  // Vérifier l'élève principal
+  // Vérifier l'élève principal (payload complet historique)
   if (lesson.student?.subscription_instances && lesson.student.subscription_instances.length > 0) {
     return true
   }
@@ -5018,6 +5038,50 @@ function hasActiveSubscription(lesson: Lesson | null): boolean {
   }
   
   return false
+}
+
+
+function planningGridKey(lesson: Lesson): string {
+  if (lesson.is_recurring_placeholder) {
+    return `p-${lesson.recurring_slot_id ?? lesson.start_time}`
+  }
+  return `l-${lesson.id}`
+}
+
+type PlanningGridMeta = {
+  studentsLabel: string
+  phonesDisplay: string | null
+  telHref: string | null
+  cardStyle: Record<string, string>
+  hasTeacherConflict: boolean
+  overlapsRecurring: boolean
+  hasAbo: boolean
+  rowHighlightClass: string
+  fromCancelled: boolean
+}
+
+/** Pré-calcul O(1) pour le rendu cartes/liste (évite N appels de helpers par propriété). */
+const planningGridMetaByKey = computed(() => {
+  const map = new Map<string, PlanningGridMeta>()
+  for (const lesson of lessonsForPlanningGrid.value) {
+    const phones = getLessonStudentPhonesDisplay(lesson)
+    map.set(planningGridKey(lesson), {
+      studentsLabel: getLessonStudents(lesson),
+      phonesDisplay: phones,
+      telHref: phones ? getLessonStudentTelHref(lesson) : null,
+      cardStyle: getLessonCardStyle(lesson),
+      hasTeacherConflict: planningLessonHasTeacherParallelConflict(lesson),
+      overlapsRecurring: planningLessonOverlapsRecurringSeries(lesson),
+      hasAbo: hasActiveSubscription(lesson),
+      rowHighlightClass: planningLessonRowHighlightClass(lesson),
+      fromCancelled: isPlaceholderFromCancelledLesson(lesson),
+    })
+  }
+  return map
+})
+
+function getPlanningGridMeta(lesson: Lesson): PlanningGridMeta | undefined {
+  return planningGridMetaByKey.value.get(planningGridKey(lesson))
 }
 
 function formatDateFull(date: Date | null): string {
@@ -5095,16 +5159,13 @@ onMounted(async () => {
     await Promise.all([
       loadClubDisciplines(),
       loadOpenSlots(),
-      loadTeachers(),
-      loadStudents(),
       loadCourseTypes(),
+      loadPendingCertificates(),
       (async () => {
         await loadLessons()
         await loadClubRecurringSlots()
       })(),
     ])
-    // Chargement dédié CM à valider (appel explicite pour garantir l'exécution)
-    await loadPendingCertificates()
     updateAvailableDays()
   } finally {
     loading.value = false

--- a/frontend/pages/student/bookings.vue
+++ b/frontend/pages/student/bookings.vue
@@ -98,10 +98,10 @@
               <span 
                 :class="[
                   'px-3 py-1 text-xs md:text-sm font-medium rounded-full',
-                  getStatusClass(booking.status)
+                  bookingStatusClass(booking)
                 ]"
               >
-                {{ getStatusText(booking.status) }}
+                {{ bookingStatusText(booking) }}
               </span>
             </div>
 
@@ -254,8 +254,32 @@ const filteredBookings = computed(() => {
   if (selectedStatus.value === 'all') {
     return bookings.value
   }
+  if (selectedStatus.value === 'cancelled') {
+    return bookings.value.filter(isNonMaintainedBooking)
+  }
+  if (selectedStatus.value === 'confirmed') {
+    return bookings.value.filter((booking) => booking.status === 'confirmed' && !isOnClosureDay(booking))
+  }
   return bookings.value.filter(booking => booking.status === selectedStatus.value)
 })
+
+function isOnClosureDay(booking: any) {
+  return Boolean(booking.is_on_closure_day)
+}
+
+function isNonMaintainedBooking(booking: any) {
+  return booking.status === 'cancelled' || isOnClosureDay(booking)
+}
+
+function bookingStatusClass(booking: any) {
+  if (isOnClosureDay(booking)) return 'bg-orange-100 text-orange-800'
+  return getStatusClass(booking.status)
+}
+
+function bookingStatusText(booking: any) {
+  if (isOnClosureDay(booking)) return 'Fermeture club'
+  return getStatusText(booking.status)
+}
 
 // Methods
 const loadBookings = async () => {
@@ -292,7 +316,10 @@ const viewBookingDetails = (bookingId: number) => {
 
 const canCancel = (booking: any) => {
   const startTime = booking.start_time ?? booking.lesson?.start_time
-  return ['pending', 'confirmed'].includes(booking.status) && startTime && new Date(startTime) > new Date()
+  return ['pending', 'confirmed'].includes(booking.status)
+    && !isOnClosureDay(booking)
+    && startTime
+    && new Date(startTime) > new Date()
 }
 
 const canRate = (booking: any) => {

--- a/frontend/pages/student/dashboard.vue
+++ b/frontend/pages/student/dashboard.vue
@@ -415,9 +415,20 @@ const currentMonthLabel = computed(() => {
 })
 
 // Methods
+function isLessonOnClosureDay(lesson: { is_on_closure_day?: boolean }) {
+  return Boolean(lesson?.is_on_closure_day)
+}
+
+function isNonMaintainedLesson(lesson: { status?: string; is_on_closure_day?: boolean }) {
+  return lesson?.status === 'cancelled' || isLessonOnClosureDay(lesson)
+}
+
 const loadUpcomingLessons = async () => {
   try {
-    const params = { active_student_id: studentScopeStore.apiScopeParam }
+    const params: Record<string, unknown> = {
+      active_student_id: studentScopeStore.apiScopeParam,
+      include_cancelled: true,
+    }
     const response = await $api.get('/student/bookings', { params })
     if (response.data.success) {
       const bookings = response.data.data || []
@@ -428,7 +439,9 @@ const loadUpcomingLessons = async () => {
         .filter((lesson: any) => {
           if (!lesson.start_time) return false
           const lessonDate = new Date(lesson.start_time)
-          return lessonDate > now && lessonDate <= oneMonthLater && ['confirmed', 'pending'].includes(lesson.status)
+          return lessonDate > now && lessonDate <= oneMonthLater
+            && ['confirmed', 'pending'].includes(lesson.status)
+            && !isLessonOnClosureDay(lesson)
         })
         .sort((a: any, b: any) => {
           const dateA = new Date(a.start_time)
@@ -439,7 +452,7 @@ const loadUpcomingLessons = async () => {
         .filter((lesson: any) => {
           if (!lesson.start_time) return false
           const lessonDate = new Date(lesson.start_time)
-          return lessonDate > now && lessonDate <= oneMonthLater && lesson.status === 'cancelled'
+          return lessonDate > now && lessonDate <= oneMonthLater && isNonMaintainedLesson(lesson)
         })
         .sort((a: any, b: any) => {
           const dateA = new Date(b.start_time)
@@ -448,7 +461,7 @@ const loadUpcomingLessons = async () => {
         })
       cancellationsThisMonth.value = bookings
         .filter((lesson: any) => {
-          if (!lesson.start_time || lesson.status !== 'cancelled') return false
+          if (!lesson.start_time || !isNonMaintainedLesson(lesson)) return false
           const d = new Date(lesson.start_time)
           const today = new Date()
           return d.getFullYear() === today.getFullYear() && d.getMonth() === today.getMonth()
@@ -483,7 +496,7 @@ const loadUpcomingLessons = async () => {
         .filter((lesson: any) => {
           if (!lesson.start_time) return false
           const lessonDate = new Date(lesson.start_time)
-          return lessonDate > now && lessonDate <= oneMonthLater && lesson.status === 'cancelled'
+          return lessonDate > now && lessonDate <= oneMonthLater && isNonMaintainedLesson(lesson)
         })
         .sort((a: any, b: any) => {
           const dateA = new Date(b.start_time)
@@ -493,7 +506,7 @@ const loadUpcomingLessons = async () => {
       const today = new Date()
       cancellationsThisMonth.value = history
         .filter((lesson: any) => {
-          if (!lesson.start_time || lesson.status !== 'cancelled') return false
+          if (!lesson.start_time || !isNonMaintainedLesson(lesson)) return false
           const d = new Date(lesson.start_time)
           return d.getFullYear() === today.getFullYear() && d.getMonth() === today.getMonth()
         })

--- a/frontend/tests/e2e/club/planning-perf.spec.ts
+++ b/frontend/tests/e2e/club/planning-perf.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test'
+import { loginAsClub } from '../utils/auth'
+
+/**
+ * Anti-régression perf planning club :
+ * - GET /lessons?context=planning au chargement
+ * - pas de GET /club/students ni /club/teachers au cold start
+ * - grille visible (data-testid)
+ */
+test.describe('Planning club — perf & régression réseau', () => {
+  test('cold start : context=planning, pas de students/teachers', async ({ page }) => {
+    const lessonsUrls: string[] = []
+    const studentsUrls: string[] = []
+    const teachersUrls: string[] = []
+
+    page.on('request', (req) => {
+      const url = req.url()
+      if (!/\/api\//.test(url) && !/lessons|students|teachers/.test(url)) {
+        // encore matcher les paths relatifs via base
+      }
+      if (url.includes('/lessons') && !url.includes('pending-certificates') && req.method() === 'GET') {
+        lessonsUrls.push(url)
+      }
+      if (url.includes('/club/students') && req.method() === 'GET') {
+        studentsUrls.push(url)
+      }
+      if (url.includes('/club/teachers') && req.method() === 'GET') {
+        teachersUrls.push(url)
+      }
+    })
+
+    await loginAsClub(page)
+
+    // Reset counters after login (dashboard peut appeler d'autres APIs)
+    lessonsUrls.length = 0
+    studentsUrls.length = 0
+    teachersUrls.length = 0
+
+    await page.goto('/club/planning', { waitUntil: 'networkidle' })
+    await expect(page.getByTestId('planning-view')).toBeVisible({ timeout: 30000 })
+    await expect(page.getByRole('heading', { name: /planning/i })).toBeVisible()
+
+    // Attendre un peu que le Promise.all du mount se termine
+    await page.waitForTimeout(1500)
+
+    const planningLessons = lessonsUrls.filter((u) => u.includes('context=planning') || u.includes('context%3Dplanning'))
+    expect(
+      planningLessons.length,
+      `Attendu GET /lessons?context=planning, reçu: ${JSON.stringify(lessonsUrls)}`,
+    ).toBeGreaterThan(0)
+
+    expect(
+      studentsUrls.length,
+      `GET /club/students ne doit pas partir au cold start, reçu: ${JSON.stringify(studentsUrls)}`,
+    ).toBe(0)
+
+    expect(
+      teachersUrls.length,
+      `GET /club/teachers ne doit pas partir au cold start, reçu: ${JSON.stringify(teachersUrls)}`,
+    ).toBe(0)
+  })
+
+  test('sélection créneau affiche la section cours programmés', async ({ page }) => {
+    await loginAsClub(page)
+    await page.goto('/club/planning', { waitUntil: 'networkidle' })
+    await expect(page.getByTestId('planning-view')).toBeVisible({ timeout: 30000 })
+
+    const slot = page.getByTestId('open-slot').first()
+    if (await slot.count() === 0) {
+      test.skip(true, 'Aucun créneau ouvert en environnement de test')
+      return
+    }
+
+    await slot.click()
+    await expect(page.getByTestId('scheduled-lessons-section')).toBeVisible()
+    await expect(page.getByText(/cours programmés/i)).toBeVisible()
+  })
+
+  test('ouverture créer un cours déclenche le lazy-load teachers/students', async ({ page }) => {
+    const studentsUrls: string[] = []
+    const teachersUrls: string[] = []
+
+    page.on('request', (req) => {
+      const url = req.url()
+      if (url.includes('/club/students') && req.method() === 'GET') studentsUrls.push(url)
+      if (url.includes('/club/teachers') && req.method() === 'GET') teachersUrls.push(url)
+    })
+
+    await loginAsClub(page)
+    await page.goto('/club/planning', { waitUntil: 'networkidle' })
+    await expect(page.getByTestId('planning-view')).toBeVisible({ timeout: 30000 })
+
+    studentsUrls.length = 0
+    teachersUrls.length = 0
+
+    const slot = page.getByTestId('open-slot').first()
+    if (await slot.count() === 0) {
+      test.skip(true, 'Aucun créneau ouvert en environnement de test')
+      return
+    }
+    await slot.click()
+
+    const createBtn = page.getByRole('button', { name: /créer un cours/i })
+    await expect(createBtn).toBeVisible({ timeout: 10000 })
+    await createBtn.click()
+
+    await expect(page.locator('[role="dialog"], [data-testid="create-lesson-modal"]').first()).toBeVisible({
+      timeout: 15000,
+    })
+
+    await page.waitForTimeout(2000)
+
+    expect(
+      teachersUrls.length + studentsUrls.length,
+      `Lazy teachers/students attendu à l'ouverture modale. teachers=${JSON.stringify(teachersUrls)} students=${JSON.stringify(studentsUrls)}`,
+    ).toBeGreaterThan(0)
+  })
+})

--- a/frontend/tests/unit/login.test.ts
+++ b/frontend/tests/unit/login.test.ts
@@ -74,7 +74,7 @@ describe('Page de connexion', () => {
     it('a un bouton de soumission', () => {
         const submitButton = wrapper.find('button[type="submit"]')
         expect(submitButton.exists()).toBe(true)
-        expect(submitButton.text()).toContain('Se connecter')
+        expect(submitButton.text()).toContain('Connexion')
     })
 
     it('a une case à cocher "Se souvenir de moi"', () => {

--- a/frontend/tests/unit/usePlanningLessonIndex.test.ts
+++ b/frontend/tests/unit/usePlanningLessonIndex.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildLessonsByLocalDate,
+  filterLessonsForOpenSlot,
+  lessonHasActiveSubscriptionBadge,
+  toLocalHm,
+  toLocalYmd,
+} from '~/composables/planning/usePlanningLessonIndex'
+
+const formatTime = (t: string) => t.substring(0, 5)
+
+describe('toLocalYmd / toLocalHm', () => {
+  it('formate une date locale YYYY-MM-DD et HH:mm', () => {
+    const d = new Date(2026, 6, 31, 9, 5, 0) // 31 juil. 2026 09:05
+    expect(toLocalYmd(d)).toBe('2026-07-31')
+    expect(toLocalHm(d)).toBe('09:05')
+  })
+})
+
+describe('buildLessonsByLocalDate', () => {
+  it('indexe par jour local et ignore les start_time invalides', () => {
+    const lessons = [
+      { id: 1, start_time: '2026-07-31T10:00:00' },
+      { id: 2, start_time: '2026-07-31T11:00:00' },
+      { id: 3, start_time: '2026-08-01T09:00:00' },
+      { id: 4, start_time: null },
+      { id: 5, start_time: 'not-a-date' },
+    ]
+    const map = buildLessonsByLocalDate(lessons)
+    expect(map.get('2026-07-31')?.map((l) => l.id)).toEqual([1, 2])
+    expect(map.get('2026-08-01')?.map((l) => l.id)).toEqual([3])
+    expect(map.has('invalid')).toBe(false)
+  })
+})
+
+describe('filterLessonsForOpenSlot', () => {
+  const slot = { day_of_week: 5, start_time: '09:00:00', end_time: '12:00:00' } // vendredi
+
+  it('ne garde que les cours du jour et dans la plage horaire', () => {
+    // vendredi 31 juil. 2026
+    const candidates = [
+      { id: 1, start_time: '2026-07-31T09:00:00' },
+      { id: 2, start_time: '2026-07-31T11:30:00' },
+      { id: 3, start_time: '2026-07-31T12:00:00' }, // fin exclusive
+      { id: 4, start_time: '2026-07-30T10:00:00' }, // jeudi
+    ]
+    const filtered = filterLessonsForOpenSlot(candidates, slot, formatTime)
+    expect(filtered.map((l) => l.id)).toEqual([1, 2])
+  })
+
+  it('retourne vide si aucun candidat', () => {
+    expect(filterLessonsForOpenSlot([], slot, formatTime)).toEqual([])
+  })
+})
+
+describe('lessonHasActiveSubscriptionBadge', () => {
+  it('vrai pour placeholder récurrent', () => {
+    expect(lessonHasActiveSubscriptionBadge({ is_recurring_placeholder: true })).toBe(true)
+  })
+
+  it('vrai si subscription_instances sur le cours (payload slim)', () => {
+    expect(lessonHasActiveSubscriptionBadge({
+      subscription_instances: [{ id: 12 }],
+    })).toBe(true)
+  })
+
+  it('vrai si abo actif sur student (payload historique)', () => {
+    expect(lessonHasActiveSubscriptionBadge({
+      student: { subscription_instances: [{ id: 1 }] },
+    })).toBe(true)
+  })
+
+  it('faux sans lien abo', () => {
+    expect(lessonHasActiveSubscriptionBadge({
+      id: 1,
+      subscription_instances: [],
+      student: { subscription_instances: [] },
+      students: [],
+    } as any)).toBe(false)
+  })
+})

--- a/tests/Feature/Api/ClubClosureDayTest.php
+++ b/tests/Feature/Api/ClubClosureDayTest.php
@@ -16,6 +16,7 @@ use App\Models\Teacher;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -362,5 +363,220 @@ class ClubClosureDayTest extends TestCase
         } finally {
             Carbon::setTestNow();
         }
+    }
+
+    /**
+     * @return array{club: \App\Models\Club, teacher: Teacher, student: Student, day: string, lesson: Lesson}
+     */
+    private function seedStudentLessonOnFutureDay(): array
+    {
+        $studentUser = \App\Models\User::factory()->create([
+            'role' => 'student',
+            'status' => 'active',
+            'is_active' => true,
+        ]);
+        $student = Student::factory()->create(['user_id' => $studentUser->id]);
+
+        $clubUser = $this->actingAsClub();
+        $club = $clubUser->getFirstClub();
+        $teacher = Teacher::factory()->create(['club_id' => $club->id]);
+        $courseType = CourseType::factory()->create();
+        $location = Location::factory()->create();
+
+        $day = Carbon::now()->addDays(12)->format('Y-m-d');
+        $lesson = Lesson::factory()
+            ->forClub($club)
+            ->forTeacher($teacher)
+            ->forStudent($student)
+            ->confirmed()
+            ->create([
+                'course_type_id' => $courseType->id,
+                'location_id' => $location->id,
+                'start_time' => $day.' 10:00:00',
+                'end_time' => $day.' 11:00:00',
+            ]);
+
+        return [
+            'club' => $club,
+            'teacher' => $teacher,
+            'student' => $student,
+            'studentUser' => $studentUser,
+            'clubUser' => $clubUser,
+            'day' => $day,
+            'lesson' => $lesson,
+        ];
+    }
+
+    #[Test]
+    public function closure_day_hides_lessons_from_student_bookings_by_default(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        Sanctum::actingAs($seed['studentUser']);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/student/bookings');
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertNotContains($seed['lesson']->id, $ids);
+        $this->assertSame('confirmed', $seed['lesson']->fresh()->status);
+    }
+
+    #[Test]
+    public function closure_day_lessons_visible_with_include_cancelled_and_flagged(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        Sanctum::actingAs($seed['studentUser']);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/student/bookings?include_cancelled=true');
+        $response->assertStatus(200);
+
+        $row = collect($response->json('data'))->firstWhere('id', $seed['lesson']->id);
+        $this->assertNotNull($row);
+        $this->assertTrue((bool) $row['is_on_closure_day']);
+        $this->assertSame('confirmed', $row['status']);
+    }
+
+    #[Test]
+    public function reopening_closure_day_restores_student_booking_visibility(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => false,
+        ])->assertStatus(200);
+
+        Sanctum::actingAs($seed['studentUser']);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/student/bookings');
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertContains($seed['lesson']->id, $ids);
+    }
+
+    #[Test]
+    public function closure_day_on_club_a_does_not_hide_lesson_on_club_b_same_date(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $otherClub = \App\Models\Club::factory()->create();
+        $otherTeacher = Teacher::factory()->create(['club_id' => $otherClub->id]);
+        $otherLesson = Lesson::factory()
+            ->forClub($otherClub)
+            ->forTeacher($otherTeacher)
+            ->forStudent($seed['student'])
+            ->confirmed()
+            ->create([
+                'course_type_id' => $seed['lesson']->course_type_id,
+                'location_id' => $seed['lesson']->location_id,
+                'start_time' => $seed['day'].' 14:00:00',
+                'end_time' => $seed['day'].' 15:00:00',
+            ]);
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        Sanctum::actingAs($seed['studentUser']);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/student/bookings');
+        $ids = collect($response->json('data'))->pluck('id')->all();
+
+        $this->assertNotContains($seed['lesson']->id, $ids);
+        $this->assertContains($otherLesson->id, $ids);
+    }
+
+    #[Test]
+    public function club_lessons_index_still_includes_lessons_on_closure_day(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        $response = $this->getJson('/api/lessons?date_from='.$seed['day'].'&date_to='.$seed['day']);
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertContains($seed['lesson']->id, $ids);
+    }
+
+    #[Test]
+    public function teacher_lessons_index_excludes_lessons_on_closure_day(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        $teacherUser = \App\Models\User::factory()->create([
+            'role' => 'teacher',
+            'status' => 'active',
+            'is_active' => true,
+        ]);
+        $seed['teacher']->update(['user_id' => $teacherUser->id]);
+
+        Sanctum::actingAs($teacherUser);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/lessons?date_from='.$seed['day'].'&date_to='.$seed['day']);
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertNotContains($seed['lesson']->id, $ids);
+    }
+
+    #[Test]
+    public function closure_day_hides_lessons_from_student_bookings_with_confirmed_status_filter(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        Sanctum::actingAs($seed['studentUser']);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/student/bookings?status=confirmed');
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertNotContains($seed['lesson']->id, $ids);
     }
 }

--- a/tests/Feature/Api/ClubClosureDayTest.php
+++ b/tests/Feature/Api/ClubClosureDayTest.php
@@ -579,4 +579,70 @@ class ClubClosureDayTest extends TestCase
         $ids = collect($response->json('data'))->pluck('id')->all();
         $this->assertNotContains($seed['lesson']->id, $ids);
     }
+
+    #[Test]
+    public function closure_day_hides_lessons_from_student_lessons_index(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        Sanctum::actingAs($seed['studentUser']);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/lessons?date_from='.$seed['day'].'&date_to='.$seed['day']);
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertNotContains($seed['lesson']->id, $ids);
+    }
+
+    #[Test]
+    public function lesson_history_includes_closure_day_lessons_with_flag(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        Sanctum::actingAs($seed['studentUser']);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/student/lesson-history');
+        $response->assertStatus(200);
+
+        $row = collect($response->json('data'))->firstWhere('id', $seed['lesson']->id);
+        $this->assertNotNull($row);
+        $this->assertTrue((bool) $row['is_on_closure_day']);
+        $this->assertSame('confirmed', $row['status']);
+    }
+
+    #[Test]
+    public function closure_day_hides_lessons_from_student_bookings_with_pending_status_filter(): void
+    {
+        Queue::fake();
+        $seed = $this->seedStudentLessonOnFutureDay();
+        $seed['lesson']->update(['status' => 'pending']);
+
+        $this->postJson('/api/club/closure-days', [
+            'date' => $seed['day'],
+            'closed' => true,
+        ])->assertStatus(200);
+
+        Sanctum::actingAs($seed['studentUser']);
+        $this->withHeaders(['Accept' => 'application/json']);
+
+        $response = $this->getJson('/api/student/bookings?status=pending');
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data'))->pluck('id')->all();
+        $this->assertNotContains($seed['lesson']->id, $ids);
+    }
 }

--- a/tests/Feature/Api/ClubPlanningControllerTest.php
+++ b/tests/Feature/Api/ClubPlanningControllerTest.php
@@ -661,4 +661,55 @@ class ClubPlanningControllerTest extends TestCase
             $this->assertEquals($sortedPriorities, $priorities);
         }
     }
+
+    #[Test]
+    public function availability_by_week_returns_occupancy_for_open_slots(): void
+    {
+        $date = Carbon::now()->next($this->openSlot->day_of_week)->format('Y-m-d');
+        if (Carbon::parse($date)->lt(Carbon::now()->startOfWeek())) {
+            $date = Carbon::parse($date)->addWeek()->format('Y-m-d');
+        }
+
+        Lesson::create([
+            'club_id' => $this->club->id,
+            'teacher_id' => $this->teacher->id,
+            'student_id' => $this->student->id,
+            'course_type_id' => $this->courseType->id,
+            'location_id' => $this->location->id,
+            'start_time' => $date.' 10:00:00',
+            'end_time' => $date.' 11:00:00',
+            'status' => 'confirmed',
+            'price' => 50.00,
+        ]);
+
+        $response = $this->getJson('/api/club/planning/availability-by-week?weeks=2');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true);
+
+        $weeks = $response->json('weeks');
+        $this->assertIsArray($weeks);
+        $this->assertNotEmpty($weeks);
+
+        $foundOccupied = false;
+        foreach ($weeks as $week) {
+            foreach ($week['slots'] ?? [] as $slot) {
+                if ((int) ($slot['slot_id'] ?? 0) !== (int) $this->openSlot->id) {
+                    continue;
+                }
+                foreach ($slot['dates'] ?? [] as $day) {
+                    if (($day['date'] ?? '') !== $date) {
+                        continue;
+                    }
+                    foreach ($day['plages'] ?? [] as $plage) {
+                        if (($plage['time'] ?? '') === '10:00' && (int) ($plage['occupied'] ?? 0) >= 1) {
+                            $foundOccupied = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        $this->assertTrue($foundOccupied, 'La plage 10:00 du créneau doit compter 1 occupation');
+    }
 }

--- a/tests/Feature/Api/LessonControllerTest.php
+++ b/tests/Feature/Api/LessonControllerTest.php
@@ -806,4 +806,31 @@ class LessonControllerTest extends TestCase
             "gain insuffisant: planning={$planningCount} default={$defaultCount}"
         );
     }
+
+    /** @test */
+    public function default_index_still_includes_remaining_when_instances_serialized(): void
+    {
+        $user = $this->actingAsClub();
+        $club = \App\Models\Club::find($user->club_id);
+        $context = $this->createSubscriptionInstanceForClub($club, 'DEFAULT-REM');
+
+        $lesson = $this->createLessonForSubscriptionContext($context, $club, [
+            'start_time' => now()->addDays(3)->setTime(10, 0),
+            'end_time' => now()->addDays(3)->setTime(11, 0),
+        ]);
+        $context['instance']->lessons()->attach($lesson->id);
+
+        $from = now()->toDateString();
+        $to = now()->addWeeks(2)->toDateString();
+
+        $response = $this->getJson("/api/lessons?date_from={$from}&date_to={$to}");
+        $response->assertStatus(200);
+        $row = collect($response->json('data'))->firstWhere('id', $lesson->id);
+        $this->assertNotNull($row);
+
+        $instances = $row['subscription_instances'] ?? [];
+        $this->assertNotEmpty($instances);
+        // Path non-planning : appends historiques toujours présents (pas de régression silencieuse)
+        $this->assertArrayHasKey('remaining_bookable', $instances[0]);
+    }
 }

--- a/tests/Feature/Api/LessonControllerTest.php
+++ b/tests/Feature/Api/LessonControllerTest.php
@@ -711,4 +711,99 @@ class LessonControllerTest extends TestCase
         $this->assertEquals(0, $context['instance']->fresh()->lessons_used);
         $this->assertEquals(10, $context['instance']->fresh()->getRemainingAttachmentSlots());
     }
+
+    /** @test */
+    public function planning_context_returns_slim_payload_without_remaining_appends(): void
+    {
+        $user = $this->actingAsClub();
+        $club = \App\Models\Club::find($user->club_id);
+        $context = $this->createSubscriptionInstanceForClub($club, 'PLAN-SLIM');
+
+        $lesson = $this->createLessonForSubscriptionContext($context, $club, [
+            'start_time' => now()->addDays(2)->setTime(10, 0),
+            'end_time' => now()->addDays(2)->setTime(11, 0),
+        ]);
+        $context['instance']->lessons()->attach($lesson->id);
+
+        $from = now()->toDateString();
+        $to = now()->addWeeks(2)->toDateString();
+
+        $response = $this->getJson("/api/lessons?context=planning&date_from={$from}&date_to={$to}");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true);
+
+        $rows = $response->json('data');
+        $this->assertIsArray($rows);
+        $this->assertNotEmpty($rows);
+
+        $row = collect($rows)->firstWhere('id', $lesson->id);
+        $this->assertNotNull($row);
+        $this->assertArrayHasKey('teacher', $row);
+        $this->assertArrayHasKey('subscription_instances', $row);
+        $this->assertArrayNotHasKey('club', $row);
+        $this->assertArrayNotHasKey('location', $row);
+
+        $instances = $row['subscription_instances'] ?? [];
+        $this->assertNotEmpty($instances);
+        $this->assertArrayHasKey('id', $instances[0]);
+        $this->assertArrayNotHasKey('remaining_bookable', $instances[0]);
+        $this->assertArrayNotHasKey('remaining_consumed', $instances[0]);
+        $this->assertArrayNotHasKey('remaining_lessons', $instances[0]);
+
+        // Élève sans remaining_* ni templates (subscription_instances = ids actifs seulement)
+        if (isset($row['student']['subscription_instances'])) {
+            foreach ($row['student']['subscription_instances'] as $si) {
+                $this->assertArrayHasKey('id', $si);
+                $this->assertArrayNotHasKey('remaining_bookable', $si);
+            }
+        }
+    }
+
+    /**
+     * Mesure : context=planning doit faire nettement moins de requêtes SQL
+     * qu'un index classique (évite remaining_* N+1 par instance).
+     *
+     * @test
+     */
+    public function planning_context_uses_fewer_queries_than_default_index(): void
+    {
+        $user = $this->actingAsClub();
+        $club = \App\Models\Club::find($user->club_id);
+
+        for ($i = 0; $i < 8; $i++) {
+            $context = $this->createSubscriptionInstanceForClub($club, 'PERF-'.$i);
+            $lesson = $this->createLessonForSubscriptionContext($context, $club, [
+                'start_time' => now()->addDays($i + 1)->setTime(10, 0),
+                'end_time' => now()->addDays($i + 1)->setTime(11, 0),
+            ]);
+            $context['instance']->lessons()->attach($lesson->id);
+        }
+
+        $from = now()->toDateString();
+        $to = now()->addWeeks(2)->toDateString();
+
+        \Illuminate\Support\Facades\DB::flushQueryLog();
+        \Illuminate\Support\Facades\DB::enableQueryLog();
+        $this->getJson("/api/lessons?date_from={$from}&date_to={$to}")->assertStatus(200);
+        $defaultCount = count(\Illuminate\Support\Facades\DB::getQueryLog());
+
+        \Illuminate\Support\Facades\DB::flushQueryLog();
+        \Illuminate\Support\Facades\DB::enableQueryLog();
+        $this->getJson("/api/lessons?context=planning&date_from={$from}&date_to={$to}")->assertStatus(200);
+        $planningCount = count(\Illuminate\Support\Facades\DB::getQueryLog());
+        \Illuminate\Support\Facades\DB::disableQueryLog();
+
+        $this->assertLessThan(
+            $defaultCount,
+            $planningCount,
+            "planning ({$planningCount}) doit être < default ({$defaultCount})"
+        );
+        // Au moins ~30% de requêtes en moins (remaining_* N+1 évité)
+        $this->assertLessThanOrEqual(
+            (int) floor($defaultCount * 0.7),
+            $planningCount,
+            "gain insuffisant: planning={$planningCount} default={$defaultCount}"
+        );
+    }
 }

--- a/tests/Unit/Http/Resources/PlanningLessonResourceTest.php
+++ b/tests/Unit/Http/Resources/PlanningLessonResourceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit\Http\Resources;
+
+use App\Http\Resources\PlanningLessonResource;
+use App\Models\CourseType;
+use App\Models\Lesson;
+use App\Models\Student;
+use App\Models\Subscription;
+use App\Models\SubscriptionInstance;
+use App\Models\SubscriptionTemplate;
+use App\Models\Teacher;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class PlanningLessonResourceTest extends TestCase
+{
+    /** @test */
+    public function it_exposes_grid_fields_without_remaining_appends_or_club_location(): void
+    {
+        $clubUser = $this->actingAsClub();
+        $club = \App\Models\Club::find($clubUser->club_id);
+
+        $teacherUser = User::factory()->create(['name' => 'Coach Grid']);
+        $teacher = Teacher::factory()->create(['user_id' => $teacherUser->id]);
+        $teacher->clubs()->attach($club->id, ['is_active' => true, 'joined_at' => now()]);
+
+        $studentUser = User::factory()->create(['name' => 'Élève Grid', 'phone' => '0600000001']);
+        $student = Student::factory()->create([
+            'user_id' => $studentUser->id,
+            'club_id' => $club->id,
+            'phone' => '0600000002',
+        ]);
+
+        $discipline = \App\Models\Discipline::factory()->create();
+        $courseType = CourseType::factory()->create([
+            'name' => 'Individuel',
+            'discipline_id' => $discipline->id,
+        ]);
+
+        $template = SubscriptionTemplate::create([
+            'club_id' => $club->id,
+            'model_number' => 'RES-GRID',
+            'name' => 'Template Grid',
+            'total_lessons' => 10,
+            'validity_months' => 4,
+            'price' => 200,
+            'is_active' => true,
+        ]);
+        $subscription = Subscription::create([
+            'club_id' => $club->id,
+            'subscription_template_id' => $template->id,
+            'subscription_number' => 'SUB-GRID',
+        ]);
+        $instance = SubscriptionInstance::create([
+            'subscription_id' => $subscription->id,
+            'lessons_used' => 0,
+            'started_at' => now()->subMonth(),
+            'expires_at' => now()->addMonths(3),
+            'status' => 'active',
+        ]);
+        $instance->students()->attach($student->id);
+
+        $lesson = Lesson::factory()->create([
+            'club_id' => $club->id,
+            'teacher_id' => $teacher->id,
+            'student_id' => $student->id,
+            'course_type_id' => $courseType->id,
+            'start_time' => now()->addDay()->setTime(10, 0),
+            'end_time' => now()->addDay()->setTime(11, 0),
+            'status' => 'confirmed',
+            'price' => 45,
+        ]);
+        $instance->lessons()->attach($lesson->id);
+
+        $lesson->load([
+            'teacher.user',
+            'student.user',
+            'student.subscriptionInstances' => fn ($q) => $q->select('subscription_instances.id'),
+            'students.user',
+            'courseType',
+            'subscriptionInstances' => fn ($q) => $q->select('subscription_instances.id'),
+            'lessonRecurringSlot',
+        ]);
+        $lesson->subscriptionInstances->each->setAppends([]);
+        if ($lesson->student?->relationLoaded('subscriptionInstances')) {
+            $lesson->student->subscriptionInstances->each->setAppends([]);
+        }
+
+        $payload = (new PlanningLessonResource($lesson))->resolve(Request::create('/'));
+
+        $this->assertSame($lesson->id, $payload['id']);
+        $this->assertSame('confirmed', $payload['status']);
+        $this->assertEquals(45, $payload['price']);
+        $this->assertSame('Coach Grid', $payload['teacher']['user']['name']);
+        $this->assertSame('Élève Grid', $payload['student']['user']['name']);
+        $this->assertSame('Individuel', $payload['course_type']['name']);
+        $this->assertSame('Individuel', $payload['courseType']['name']);
+        $this->assertNotEmpty($payload['subscription_instances']);
+        $this->assertArrayHasKey('id', $payload['subscription_instances'][0]);
+        $this->assertArrayNotHasKey('remaining_bookable', $payload['subscription_instances'][0]);
+        $this->assertArrayNotHasKey('club', $payload);
+        $this->assertArrayNotHasKey('location', $payload);
+        $this->assertArrayHasKey('subscription_instances', $payload['student']);
+        $this->assertArrayNotHasKey('remaining_bookable', $payload['student']['subscription_instances'][0] ?? []);
+    }
+}

--- a/tests/Unit/Services/LessonCalendarDateTest.php
+++ b/tests/Unit/Services/LessonCalendarDateTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\LessonCalendarDate;
+use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class LessonCalendarDateTest extends TestCase
+{
+    #[Test]
+    public function to_ymd_uses_configured_calendar_timezone(): void
+    {
+        config([
+            'bookyourcoach.lesson_calendar.timezone' => 'Europe/Paris',
+            'bookyourcoach.lesson_calendar.db_storage_timezone' => 'UTC',
+        ]);
+
+        $utcLate = Carbon::parse('2026-07-10 22:30:00', 'UTC');
+
+        $this->assertSame('2026-07-11', LessonCalendarDate::toYmd($utcLate));
+    }
+
+    #[Test]
+    public function sql_date_expression_uses_date_on_sqlite(): void
+    {
+        $this->assertSame(
+            'DATE(lessons.start_time)',
+            LessonCalendarDate::sqlDateExpression('lessons.start_time', \DB::connection())
+        );
+    }
+
+    #[Test]
+    public function db_storage_timezone_defaults_to_calendar_timezone_when_unset(): void
+    {
+        config([
+            'bookyourcoach.lesson_calendar.timezone' => 'Europe/Paris',
+            'bookyourcoach.lesson_calendar.db_storage_timezone' => 'Europe/Paris',
+        ]);
+
+        $this->assertSame('Europe/Paris', LessonCalendarDate::timezone());
+        $this->assertSame('Europe/Paris', LessonCalendarDate::dbStorageTimezone());
+        $this->assertSame(
+            'DATE(lessons.start_time)',
+            LessonCalendarDate::sqlDateExpression('lessons.start_time', \DB::connection())
+        );
+    }
+
+    #[Test]
+    public function where_on_calendar_date_matches_lesson_on_calendar_day_with_timezone_offset(): void
+    {
+        config([
+            'bookyourcoach.lesson_calendar.timezone' => 'Europe/Paris',
+            'bookyourcoach.lesson_calendar.db_storage_timezone' => 'UTC',
+        ]);
+
+        $club = \App\Models\Club::factory()->create();
+        $lesson = \App\Models\Lesson::factory()->forClub($club)->create([
+            'start_time' => '2026-07-10 22:30:00',
+            'end_time' => '2026-07-10 23:30:00',
+            'status' => 'confirmed',
+        ]);
+
+        $matched = \App\Models\Lesson::query()
+            ->where('id', $lesson->id);
+        LessonCalendarDate::whereOnCalendarDate($matched, 'start_time', '2026-07-11');
+        $this->assertTrue($matched->exists());
+
+        $notMatched = \App\Models\Lesson::query()
+            ->where('id', $lesson->id);
+        LessonCalendarDate::whereOnCalendarDate($notMatched, 'start_time', '2026-07-10');
+        $this->assertFalse($notMatched->exists());
+    }
+}

--- a/tests/Unit/Services/LessonReactivationServiceTest.php
+++ b/tests/Unit/Services/LessonReactivationServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Club;
+use App\Models\CourseType;
+use App\Models\Lesson;
+use App\Models\Location;
+use App\Models\Student;
+use App\Models\Subscription;
+use App\Models\SubscriptionInstance;
+use App\Models\SubscriptionRecurringSlot;
+use App\Models\SubscriptionTemplate;
+use App\Models\Teacher;
+use App\Services\LessonReactivationService;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class LessonReactivationServiceTest extends TestCase
+{
+    /** @test */
+    public function find_matching_recurring_slot_locates_cancelled_slot_by_instance_and_time(): void
+    {
+        $user = $this->actingAsClub();
+        $club = Club::find($user->club_id);
+        $teacher = Teacher::factory()->create();
+        $teacher->clubs()->attach($club->id, ['is_active' => true, 'joined_at' => now()]);
+        $student = Student::factory()->create(['club_id' => $club->id]);
+        $courseType = CourseType::factory()->create();
+        $location = Location::factory()->create();
+
+        $template = SubscriptionTemplate::create([
+            'club_id' => $club->id,
+            'model_number' => 'MATCH001',
+            'total_lessons' => 10,
+            'validity_months' => 6,
+            'price' => 100,
+            'is_active' => true,
+        ]);
+        $subscription = Subscription::create([
+            'club_id' => $club->id,
+            'subscription_template_id' => $template->id,
+            'subscription_number' => 'SUB-MATCH-'.uniqid(),
+        ]);
+        $instance = SubscriptionInstance::create([
+            'subscription_id' => $subscription->id,
+            'status' => 'active',
+            'lessons_used' => 0,
+            'started_at' => now()->subMonth(),
+            'expires_at' => now()->addMonths(3),
+        ]);
+        $instance->students()->attach($student->id);
+
+        $start = Carbon::now()->next(Carbon::MONDAY)->setTime(10, 0, 0);
+
+        $slot = SubscriptionRecurringSlot::create([
+            'subscription_instance_id' => $instance->id,
+            'teacher_id' => $teacher->id,
+            'student_id' => $student->id,
+            'day_of_week' => $start->dayOfWeek,
+            'start_time' => '10:00:00',
+            'end_time' => '11:00:00',
+            'recurring_interval' => 1,
+            'start_date' => $start->copy()->subWeek()->toDateString(),
+            'end_date' => $start->copy()->addMonths(2)->toDateString(),
+            'status' => 'cancelled',
+        ]);
+
+        $lesson = Lesson::factory()
+            ->forClub($club)
+            ->forTeacher($teacher)
+            ->forStudent($student)
+            ->create([
+                'status' => 'cancelled',
+                'start_time' => $start,
+                'end_time' => $start->copy()->addHour(),
+                'course_type_id' => $courseType->id,
+                'location_id' => $location->id,
+                'cancelled_subscription_instance_ids' => [$instance->id],
+            ]);
+
+        $matched = app(LessonReactivationService::class)->findMatchingRecurringSlot($lesson);
+
+        $this->assertNotNull($matched);
+        $this->assertSame($slot->id, $matched->id);
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /lessons?context=planning` : payload slim (`PlanningLessonResource`), sans appends `remaining_*`, `whereBetween` index-friendly
- Cold start `/club/planning` : teachers/students lazy ; Maps date + mémo cartes ; logs gated en prod
- `availability-by-week` : 1 query lessons sur l’horizon + index `date|heure` (plus 1 get/semaine)

## Test plan
- [ ] Ouvrir `/club/planning` : grille jour/créneau, badge abo 📋, placeholders récurrents
- [ ] Créer/éditer un cours (lazy teachers/students au 1er open)
- [ ] Naviguer les dates (reload chunk)
- [ ] `/club/availability` : occupations cohérentes
- [ ] `phpunit --filter=planning_context_|availability_by_week_returns_occupancy`


Made with [Cursor](https://cursor.com)